### PR TITLE
Include actual error description in failure message when an exception is expected but another is raised

### DIFF
--- a/lib/asserter.js
+++ b/lib/asserter.js
@@ -83,14 +83,19 @@ class Assertion extends TestResultReporter {
   
   _exceptionAssertion(expectedError, shouldFail) {
     let match = false;
+    let actualError = undefined;
     try {
       this._actual();
       match = !shouldFail;
-    } catch (actualError) {
+    } catch (error) {
+      actualError = error;
       const errorCheck = actualError === expectedError;
       match = shouldFail ? errorCheck : !errorCheck;
     } finally {
-      this._evaluateAssertion(match, `Expected error ${expectedError} ${notPrefix(shouldFail)} to happen`, true);
+      const failureMessage = typeof actualError !== 'undefined' ?
+          `Expected error ${expectedError} ${notPrefix(shouldFail)} to happen, but got ${actualError} instead` :
+          `Expected error ${expectedError} ${notPrefix(shouldFail)} to happen`;
+      this._evaluateAssertion(match, failureMessage, true);
     }
   }
   


### PR DESCRIPTION
## Problem
When testing exceptions and an exception other than the expected one is raised, the actual exception is not printed on the test result.

For example in this test:
```
test('test example', () => {
    assert.that(() => { throw "Error A" }).raises("Error B")
})
```

The error we get after running it, is:
```
[FAIL] test example
  => Expected error Error B  to happen
```

Note that is the same error we get if the test was:
```
test('test example', () => {
    assert.that(() => { /* No errors here */ }).raises("Error B")
})
```

## Solution
Include the actual error description in the failure message when an exception is expected but another is raised.

For the first example, the new error message would be:
```
[FAIL] test example
  => Expected error Error B  to happen, but got Error A instead
```

The error is the same for the second example (when no errors are raised).