### PR TITLE
[feature] allow to pass a regex to the raises() matcher (#39)

### DIFF
--- a/lib/asserter.js
+++ b/lib/asserter.js
@@ -108,8 +108,8 @@ class Assertion extends TestResultReporter {
   
   // Exception assertions
   
-  raises(expectedError) {
-    this._exceptionAssertion(expectedError, true);
+  raises(errorExpectation) {
+    this._exceptionAssertion(errorExpectation, true);
   }
   
   doesNotRaise(notExpectedError) {
@@ -147,7 +147,7 @@ class Assertion extends TestResultReporter {
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
-  _exceptionAssertion(expectedError, shouldFail) {
+  _exceptionAssertion(errorExpectation, shouldFail) {
     let hasFailed = false;
     let actualError = undefined;
     try {
@@ -155,14 +155,23 @@ class Assertion extends TestResultReporter {
       hasFailed = !shouldFail;
     } catch (error) {
       actualError = error;
-      const errorCheck = actualError === expectedError;
+      let errorCheck = this._checkIfErrorMatchesExpectation(errorExpectation, actualError);
       hasFailed = shouldFail ? errorCheck : !errorCheck;
     } finally {
       const toHappenOrNot = shouldFail ? this.translated('to_happen') : this.translated('not_to_happen');
-      const expectedErrorIntroduction = `${this.translated('expected')} ${this.translated('expecting_error')} ${this._prettyPrint(expectedError)} ${toHappenOrNot}`;
+      const expectedErrorIntroduction = `${this.translated('expected')} ${this.translated('expecting_error')} ${this._prettyPrint(errorExpectation)} ${toHappenOrNot}`;
       const failureMessage = typeof actualError !== 'undefined' ?
           `${expectedErrorIntroduction}, ${this.translated('but_got')} ${this._prettyPrint(actualError)} ${this.translated('instead')}` : expectedErrorIntroduction;
       this._reportAssertionResult(hasFailed, failureMessage, true);
+    }
+  }
+  
+  _checkIfErrorMatchesExpectation(errorExpectation, actualError) {
+    const expectationIsRegex = errorExpectation.__proto__.hasOwnProperty('test');
+    if (expectationIsRegex) {
+      return errorExpectation.test(actualError);
+    } else {
+      return actualError === errorExpectation;
     }
   }
   

--- a/tests/core/asserter_test.js
+++ b/tests/core/asserter_test.js
@@ -2,6 +2,7 @@
 
 const { suite, test, assert } = require('../../testy');
 const { Asserter } = require('../../lib/asserter');
+const { TestSucceeded } = require('../../lib/test_result');
 const I18n = require('../../lib/i18n');
 
 const fakeRunner = {
@@ -13,12 +14,12 @@ const fakeRunner = {
 const asserter = new Asserter(fakeRunner);
 
 function expectFailDueTo(failureMessage) {
-  assert.isFalse(fakeRunner.result().isSuccess());
+  assert.isTrue(fakeRunner.result().isFailure());
   assert.areEqual(fakeRunner.result().failureMessage(), failureMessage);
 }
 
 function expectSuccess() {
-  assert.isTrue(fakeRunner.result().isSuccess());
+  assert.areEqual(fakeRunner.result(), new TestSucceeded());
 }
 
 suite('assertions behavior', () => {
@@ -222,5 +223,31 @@ suite('assertions behavior', () => {
     asserter.isNotEmpty(['hey']);
     
     expectSuccess();
+  });
+  
+  // Exception assertions
+  
+  test('raises() can receive a string and it passes when the exact string is expected', () => {
+    asserter.that(() => { throw 'an error happened' }).raises('an error happened');
+    
+    expectSuccess();
+  });
+  
+  test('raises() can receive a regex and it passes when it matches the thrown string', () => {
+    asserter.that(() => { throw 'an error happened' }).raises(/error/);
+    
+    expectSuccess();
+  });
+  
+  test('raises() can receive a regex and it passes when it matches the thrown error with message', () => {
+    asserter.that(() => { throw new TypeError('things happened') }).raises(/happened/);
+    
+    expectSuccess();
+  });
+  
+  test('raises() can receive a regex and it fails if there is not a match in the error message', () => {
+    asserter.that(() => { throw 'a terrible error' }).raises(/happiness/);
+    
+    expectFailDueTo('Expected error /happiness/ to happen, but got \'a terrible error\' instead');
   });
 });


### PR DESCRIPTION
Fixes issue #39 .

Added check for regex and 4 unit tests for the raises() matcher.