### PR TITLE
Support for Node 6.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [6.x, 8.x, 10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A very simple JS testing library, for educational purposes. Live at npm at [@pmo
 
 `npm install --save-dev @pmoo/testy`
 
+**Supported Node versions**: 6.x or higher
+
 ## Usage
 
 ### Running a single file

--- a/lib/test_runner.js
+++ b/lib/test_runner.js
@@ -101,8 +101,7 @@ class TestRunner {
   
   allFailuresAndErrors() {
     return this.suites().reduce(
-      (failures, suite) => failures.concat(suite.allFailuresAndErrors()),
-      [],
+      (failures, suite) => failures.concat(suite.allFailuresAndErrors()), []
     );
   }
   


### PR DESCRIPTION
We are just a comma away (literally) to support 6.x version.

So let's remove that problematic comma!

Also adding the 6.x build for Github Action