### PR TITLE
Improve styles of the test suite report

### DIFF
--- a/lib/console_ui.js
+++ b/lib/console_ui.js
@@ -39,8 +39,12 @@ class ConsoleUI {
   
   suiteCallbacks() {
     return {
+      onStart: suite => {
+        console.log(`\n${suite.name()}:`);
+        this._displaySeparator('-');
+      },
       onFinish: suite => {
-        this._displaySeparator();
+        this._displaySeparator('-');
         console.log(`${this.translated('summary_of')} ${suite.name()}:`);
         this._displayCountFor(suite);
         this._displaySeparator();
@@ -72,8 +76,8 @@ class ConsoleUI {
     return this._i18n.translate(key);
   }
   
-  _displayIfNonZero(quantity, word) {
-    return quantity > 0 ? `, ${quantity} ${word}` : '';
+  _displayIfNonZero(quantity, word, color = off) {
+    return quantity > 0 ? `, ${color}${quantity} ${word}${off}` : '';
   }
   
   _displayResult(result, test, color) {
@@ -84,23 +88,23 @@ class ConsoleUI {
     console.log(`  => ${detail}`);
   }
   
-  _displaySeparator() {
-    console.log('='.repeat(80));
+  _displaySeparator(character = '=') {
+    console.log(character.repeat(80));
   }
   
   _displayCountFor(runner) {
     console.log(`${runner.totalCount()} test(s)` +
-      this._displayIfNonZero(runner.successCount(), this.translated('passed')) +
-      this._displayIfNonZero(runner.failuresCount(), this.translated('failed')) +
-      this._displayIfNonZero(runner.errorsCount(), this.translated('errors')) +
+      this._displayIfNonZero(runner.successCount(), this.translated('passed'), green) +
+      this._displayIfNonZero(runner.failuresCount(), this.translated('failed'), red) +
+      this._displayIfNonZero(runner.errorsCount(), this.translated('errors'), red) +
       this._displayIfNonZero(runner.pendingCount(), this.translated('pending')) +
-      this._displayIfNonZero(runner.skippedCount(), this.translated('skipped'))
+      this._displayIfNonZero(runner.skippedCount(), this.translated('skipped'), yellow)
     );
   }
   
   displayErrorsAndFailuresSummary(runner) {
     if (runner.hasErrorsOrFailures()) {
-      console.log(this.translated('failures_summary'));
+      console.log(`\n${this.translated('failures_summary')}`);
       runner.allFailuresAndErrors().forEach(test => {
         if (test.isFailure()) {
           this._displayResult(this.translated('fail'), test, red);
@@ -114,7 +118,7 @@ class ConsoleUI {
   }
   
   _displaySummary(runner) {
-    console.log(this.translated('total'));
+    console.log(`\n${this.translated('total')}`);
     this._displayCountFor(runner);
     this._displaySeparator();
   }

--- a/lib/test_suite.js
+++ b/lib/test_suite.js
@@ -27,6 +27,7 @@ class TestSuite {
   // Executing
   
   run(failFastMode = FailFast.default()) {
+    this._callbacks.onStart(this);
     this.evaluateSuiteDefinition();
     this.runTests(failFastMode);
     this._callbacks.onFinish(this);

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -8,7 +8,7 @@ const TestRunner = require('../../lib/test_runner');
 
 const noop = () => {};
 const emptyRunnerCallbacks = { onFinish: noop };
-const emptySuiteCallbacks = { onFinish: noop };
+const emptySuiteCallbacks = { onStart: noop, onFinish: noop };
 const emptyTestCallbacks = {
   whenErrored: noop,
   whenFailed: noop,


### PR DESCRIPTION
## Changes
- Print suite name as a title before the suite results.
- Add colors to the test count summary
- Improve readability by using different kinds of separators and adding
new lines.

## Screenshots

### Before
![testy_before](https://user-images.githubusercontent.com/993337/72214822-c0cdef00-34e8-11ea-97f7-a811c224b813.png)

### After
![testy_after](https://user-images.githubusercontent.com/993337/72214823-c592a300-34e8-11ea-85a9-ee01a28cd094.png)
