### PR TITLE
[bug] includes, doesNotInclude and includesExactly criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Everything is released. Yay! :tada:
+
+## [5.0.1] - 2020-08-02
+
 ### Fixed
 
 * [[bug] includesExactly uses === as comparison](https://github.com/ngarbezza/testy/issues/119): Now the same criteria as `isEqualTo` is used in `includes`, `doesNotInclude` and `includesExactly`.
@@ -187,7 +191,8 @@ readable and extensible. It also includes a huge internal refactor to make the t
 ### Changed
 - Fix passed count at test runner level (no reported issue)
 
-[Unreleased]: https://github.com/ngarbezza/testy/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/ngarbezza/testy/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/ngarbezza/testy/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/ngarbezza/testy/compare/v4.4.0...v5.0.0
 [4.4.0]: https://github.com/ngarbezza/testy/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/ngarbezza/testy/compare/v4.2.2...v4.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Everything is released. Yay! :tada:
+### Fixed
+
+* [[bug] includesExactly uses === as comparison](https://github.com/ngarbezza/testy/issues/119): Now the same criteria as `isEqualTo` is used in `includes`, `doesNotInclude` and `includesExactly`.
 
 ## [5.0.0] - 2020-05-22
 

--- a/lib/asserter.js
+++ b/lib/asserter.js
@@ -128,20 +128,22 @@ class Assertion extends TestResultReporter {
   
   // Collection assertions
   
-  includes(object) {
-    const resultIsSuccessful = this._actual.includes(object);
-    const failureMessage = `${this.translated('include')} ${object}`;
+  includes(expectedObject, equalityCriteria) {
+    const resultIsSuccessful = this._actual.find(element =>
+      this._areConsideredEqual(element, expectedObject, equalityCriteria));
+    const failureMessage = `${this.translated('include')} ${Utils.prettyPrint(expectedObject)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
-  doesNotInclude(object) {
-    const resultIsSuccessful = !this._actual.includes(object);
-    const failureMessage = `${this.translated('not_include')} ${object}`;
+  doesNotInclude(expectedObject, equalityCriteria) {
+    const resultIsSuccessful = !this._actual.find(element =>
+      this._areConsideredEqual(element, expectedObject, equalityCriteria));
+    const failureMessage = `${this.translated('not_include')} ${Utils.prettyPrint(expectedObject)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   includesExactly(...objects) {
-    const resultIsSuccessful = Utils.haveSameElements(this._actual, objects);
+    const resultIsSuccessful = this._haveElementsConsideredEqual(this._actual, objects);
     const failureMessage = `${this.translated('include_exactly')} ${Utils.prettyPrint(objects)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
   }
@@ -214,6 +216,10 @@ class Assertion extends TestResultReporter {
     }
   }
   
+  _areConsideredEqual(objectOne, objectTwo, equalityCriteria) {
+    return EqualityAssertionStrategy.evaluate(objectOne, objectTwo, equalityCriteria).comparisonResult;
+  }
+  
   _booleanAssertion(expectedBoolean, failureMessage) {
     const resultIsSuccessful = this._actual === expectedBoolean;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
@@ -278,6 +284,20 @@ class Assertion extends TestResultReporter {
   
   _actualResultAsString() {
     return Utils.prettyPrint(this._actual);
+  }
+  
+  _haveElementsConsideredEqual(collectionOne, collectionTwo) {
+    const collectionOneArray = Array.from(collectionOne);
+    const collectionTwoArray = Array.from(collectionTwo);
+    if (collectionOneArray.length !== collectionTwoArray.length) return false;
+    for (let i = 0; i < collectionOne.length; i++) {
+      const includedInOne = collectionOne.find(element =>
+        this._areConsideredEqual(element, collectionTwoArray[i]));
+      const includedInTwo = collectionTwo.find(element =>
+        this._areConsideredEqual(element, collectionOneArray[i]));
+      if (!includedInOne || !includedInTwo) return false;
+    }
+    return true;
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,18 +53,6 @@ const allFilesMatching = (dir, regex, results = []) => {
 const prettyPrint = object =>
   util.inspect(object);
 
-const haveSameElements = (collectionOne, collectionTwo) => {
-  const collectionOneArray = Array.from(collectionOne);
-  const collectionTwoArray = Array.from(collectionTwo);
-  if (collectionOneArray.length !== collectionTwoArray.length) return false;
-  for (let i = 0; i < collectionOne.length; i++) {
-    const includedInOne = collectionOneArray.includes(collectionTwoArray[i]);
-    const includedInTwo = collectionTwoArray.includes(collectionOneArray[i]);
-    if (!includedInOne || !includedInTwo) return false;
-  }
-  return true;
-};
-
 const shuffle = array => {
   let currentIndex = array.length;
   let temporaryValue;
@@ -97,7 +85,6 @@ module.exports = {
   resolvePathFor,
   allFilesMatching,
   prettyPrint,
-  haveSameElements,
   shuffle,
   isString,
   isFunction,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@pmoo/testy",
-  "version": "4.4.0",
+  "version": "5.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmoo/testy",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A minimal testing library, for educational purposes.",
   "homepage": "https://ngarbezza.github.io/testy/",
   "repository": {

--- a/tests/core/assertions/collection_assertions_test.js
+++ b/tests/core/assertions/collection_assertions_test.js
@@ -17,13 +17,19 @@ suite('collection assertions', () => {
   test('includes does not pass if the actual object is not an array', () => {
     asserter.that([]).includes('hey');
     
-    expectFailureDueTo("Expected [] to include hey");
+    expectFailureDueTo("Expected [] to include 'hey'");
+  });
+  
+  test('includes works with non-primitives', () => {
+    asserter.that([{ a: '1' }]).includes({ a: '1' });
+    
+    expectSuccess();
   });
   
   test('doesNotInclude fails if the object is in the array', () => {
     asserter.that(['hey']).doesNotInclude('hey');
     
-    expectFailureDueTo("Expected [ 'hey' ] to not include hey");
+    expectFailureDueTo("Expected [ 'hey' ] to not include 'hey'");
   });
   
   test('doesNotInclude passes if the object is not an array', () => {
@@ -32,8 +38,20 @@ suite('collection assertions', () => {
     expectSuccess();
   });
   
+  test('doesNotInclude fails properly with non-primitives', () => {
+    asserter.that([{ a: '1' }]).doesNotInclude({ a: '1' });
+  
+    expectFailureDueTo("Expected [ { a: '1' } ] to not include { a: '1' }");
+  });
+  
   test('includesExactly passes with a single object included', () => {
     asserter.that(['hey']).includesExactly('hey');
+    
+    expectSuccess();
+  });
+  
+  test('includesExactly passes using a non-primitive single object', () => {
+    asserter.that([{ a: '1' }]).includesExactly({ a: '1' });
     
     expectSuccess();
   });


### PR DESCRIPTION
[[bug] includesExactly uses === as comparison](https://github.com/ngarbezza/testy/issues/119): Now the same criteria as `isEqualTo` is used in `includes`, `doesNotInclude` and `includesExactly`.