### PR TITLE
Release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Everything is released. Yay! :tada:
 
+## [5.0.0] - 2020-05-22
+
+:five: :tada: new release! Including some **breaking changes**.
+
+### Breaking changes
+
+* There's no need for a testy runner file, now there's a testy binary that runs the suites for you based on a configuration file. In other words, before: you have to call testy; now: testy calls you :smiley:
+* Node 6.x is no longer supported. Now Node 8.x is the minimum version required.
+
+### Added
+
+* [[feature] configuration to run tests in random order](https://github.com/ngarbezza/testy/issues/73): to ensure test isolation and therefore having robust suites :muscle:
+* [[feature] allow to pass multiple test paths to run testy](https://github.com/ngarbezza/testy/issues/86): this allows to have more flexibility and control which files we want to run
+* [[documentation] docs in Spanish](https://github.com/ngarbezza/testy/issues/90): now both README and CONTRIBUTING files are translated and updated in English and Spanish.
+* [[feature] testy binary](https://github.com/ngarbezza/testy/issues/17): **breaking change**, this makes testy more easy to be executed. There's a `testy` script that can be run globally or through `npx`.
+* [[feature] read configuration parameters from JSON file](https://github.com/ngarbezza/testy/issues/94): in order to run testy from a binary file, we now need a place to specify the configuration. Starting on v5, every project can have a `.testyrc.json` with the desired configuration parameters. Default values will be used in case the file is not present. 
+* [[feature] testy start message](https://github.com/ngarbezza/testy/issues/100): now testy says "Hi!" when starting to run tests.
+* [[documentation] v5 revamped docs](https://github.com/ngarbezza/testy/issues/91): new README with all the v5 features, and a more clear step by step guide. Also, there are links for v4 docs. Spanish and English.
+* [[feature] -h/--help command line option](https://github.com/ngarbezza/testy/issues/108): now that we have a binary, we need a help option! Added a simple. 
+* [[feature] -v/--version command line option](https://github.com/ngarbezza/testy/issues/109): simple text displaying the current version.
+* [[feature] isNull() and isNotNull() assertions](https://github.com/ngarbezza/testy/issues/66): checking for null now has a specific assertion with a helpful error message.
+* [[feature] matches() assertion](https://github.com/ngarbezza/testy/issues/113): other important assertion added to the core; check if a string matches a regex (or another string!).
+
+### Changed
+
+* [version] Node 8.x is the minimum version (**breaking change**)
+* [[internal] use eslint as linter for the tool](https://github.com/ngarbezza/testy/issues/89): this is a good step forward having more consistency in this codebase.
+* [documentation] add documentation issue type: keeping the repo more accessible for contributors.
+* [documentation] explain how CI and our linter works: helpful for contributors
+
+### Fixed
+
+* [[bug] make name and body required for test suites](https://github.com/ngarbezza/testy/issues/84)
+* [[bug] isEmpty and isNotEmpty now work with Set instances](https://github.com/ngarbezza/testy/issues/111)
+
 ## [4.4.0] - 2020-01-14
 
 First release in 2020! Release emoji: :muscle:
@@ -150,7 +185,8 @@ readable and extensible. It also includes a huge internal refactor to make the t
 ### Changed
 - Fix passed count at test runner level (no reported issue)
 
-[Unreleased]: https://github.com/ngarbezza/testy/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/ngarbezza/testy/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/ngarbezza/testy/compare/v4.4.0...v5.0.0
 [4.4.0]: https://github.com/ngarbezza/testy/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/ngarbezza/testy/compare/v4.2.2...v4.3.0
 [4.2.2]: https://github.com/ngarbezza/testy/compare/v4.2.1...v4.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Everything is released. Yay! :tada:
 
+## [5.0.1] - 2020-08-02
+
+### Fixed
+
+* [[bug] includesExactly uses === as comparison](https://github.com/ngarbezza/testy/issues/119): Now the same criteria as `isEqualTo` is used in `includes`, `doesNotInclude` and `includesExactly`.
+
 ## [5.0.0] - 2020-05-22
 
 :five: :tada: new release! Including some **breaking changes**.
@@ -185,7 +191,8 @@ readable and extensible. It also includes a huge internal refactor to make the t
 ### Changed
 - Fix passed count at test runner level (no reported issue)
 
-[Unreleased]: https://github.com/ngarbezza/testy/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/ngarbezza/testy/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/ngarbezza/testy/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/ngarbezza/testy/compare/v4.4.0...v5.0.0
 [4.4.0]: https://github.com/ngarbezza/testy/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/ngarbezza/testy/compare/v4.2.2...v4.3.0

--- a/lib/asserter.js
+++ b/lib/asserter.js
@@ -128,20 +128,22 @@ class Assertion extends TestResultReporter {
   
   // Collection assertions
   
-  includes(object) {
-    const resultIsSuccessful = this._actual.includes(object);
-    const failureMessage = `${this.translated('include')} ${object}`;
+  includes(expectedObject, equalityCriteria) {
+    const resultIsSuccessful = this._actual.find(element =>
+      this._areConsideredEqual(element, expectedObject, equalityCriteria));
+    const failureMessage = `${this.translated('include')} ${Utils.prettyPrint(expectedObject)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
-  doesNotInclude(object) {
-    const resultIsSuccessful = !this._actual.includes(object);
-    const failureMessage = `${this.translated('not_include')} ${object}`;
+  doesNotInclude(expectedObject, equalityCriteria) {
+    const resultIsSuccessful = !this._actual.find(element =>
+      this._areConsideredEqual(element, expectedObject, equalityCriteria));
+    const failureMessage = `${this.translated('not_include')} ${Utils.prettyPrint(expectedObject)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   includesExactly(...objects) {
-    const resultIsSuccessful = Utils.haveSameElements(this._actual, objects);
+    const resultIsSuccessful = this._haveElementsConsideredEqual(this._actual, objects);
     const failureMessage = `${this.translated('include_exactly')} ${Utils.prettyPrint(objects)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
   }
@@ -214,6 +216,10 @@ class Assertion extends TestResultReporter {
     }
   }
   
+  _areConsideredEqual(objectOne, objectTwo, equalityCriteria) {
+    return EqualityAssertionStrategy.evaluate(objectOne, objectTwo, equalityCriteria).comparisonResult;
+  }
+  
   _booleanAssertion(expectedBoolean, failureMessage) {
     const resultIsSuccessful = this._actual === expectedBoolean;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
@@ -278,6 +284,20 @@ class Assertion extends TestResultReporter {
   
   _actualResultAsString() {
     return Utils.prettyPrint(this._actual);
+  }
+  
+  _haveElementsConsideredEqual(collectionOne, collectionTwo) {
+    const collectionOneArray = Array.from(collectionOne);
+    const collectionTwoArray = Array.from(collectionTwo);
+    if (collectionOneArray.length !== collectionTwoArray.length) return false;
+    for (let i = 0; i < collectionOne.length; i++) {
+      const includedInOne = collectionOne.find(element =>
+        this._areConsideredEqual(element, collectionTwoArray[i]));
+      const includedInTwo = collectionTwo.find(element =>
+        this._areConsideredEqual(element, collectionOneArray[i]));
+      if (!includedInOne || !includedInTwo) return false;
+    }
+    return true;
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,18 +53,6 @@ const allFilesMatching = (dir, regex, results = []) => {
 const prettyPrint = object =>
   util.inspect(object);
 
-const haveSameElements = (collectionOne, collectionTwo) => {
-  const collectionOneArray = Array.from(collectionOne);
-  const collectionTwoArray = Array.from(collectionTwo);
-  if (collectionOneArray.length !== collectionTwoArray.length) return false;
-  for (let i = 0; i < collectionOne.length; i++) {
-    const includedInOne = collectionOneArray.includes(collectionTwoArray[i]);
-    const includedInTwo = collectionTwoArray.includes(collectionOneArray[i]);
-    if (!includedInOne || !includedInTwo) return false;
-  }
-  return true;
-};
-
 const shuffle = array => {
   let currentIndex = array.length;
   let temporaryValue;
@@ -97,7 +85,6 @@ module.exports = {
   resolvePathFor,
   allFilesMatching,
   prettyPrint,
-  haveSameElements,
   shuffle,
   isString,
   isFunction,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@pmoo/testy",
-  "version": "4.4.0",
+  "version": "5.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmoo/testy",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A minimal testing library, for educational purposes.",
   "homepage": "https://ngarbezza.github.io/testy/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmoo/testy",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "A minimal testing library, for educational purposes.",
   "homepage": "https://ngarbezza.github.io/testy/",
   "repository": {

--- a/tests/core/assertions/collection_assertions_test.js
+++ b/tests/core/assertions/collection_assertions_test.js
@@ -17,13 +17,19 @@ suite('collection assertions', () => {
   test('includes does not pass if the actual object is not an array', () => {
     asserter.that([]).includes('hey');
     
-    expectFailureDueTo("Expected [] to include hey");
+    expectFailureDueTo("Expected [] to include 'hey'");
+  });
+  
+  test('includes works with non-primitives', () => {
+    asserter.that([{ a: '1' }]).includes({ a: '1' });
+    
+    expectSuccess();
   });
   
   test('doesNotInclude fails if the object is in the array', () => {
     asserter.that(['hey']).doesNotInclude('hey');
     
-    expectFailureDueTo("Expected [ 'hey' ] to not include hey");
+    expectFailureDueTo("Expected [ 'hey' ] to not include 'hey'");
   });
   
   test('doesNotInclude passes if the object is not an array', () => {
@@ -32,8 +38,20 @@ suite('collection assertions', () => {
     expectSuccess();
   });
   
+  test('doesNotInclude fails properly with non-primitives', () => {
+    asserter.that([{ a: '1' }]).doesNotInclude({ a: '1' });
+  
+    expectFailureDueTo("Expected [ { a: '1' } ] to not include { a: '1' }");
+  });
+  
   test('includesExactly passes with a single object included', () => {
     asserter.that(['hey']).includesExactly('hey');
+    
+    expectSuccess();
+  });
+  
+  test('includesExactly passes using a non-primitive single object', () => {
+    asserter.that([{ a: '1' }]).includesExactly({ a: '1' });
     
     expectSuccess();
   });


### PR DESCRIPTION
### Fixed

* [[bug] includesExactly uses === as comparison](https://github.com/ngarbezza/testy/issues/119): Now the same criteria as `isEqualTo` is used in `includes`, `doesNotInclude` and `includesExactly`.