### PR TITLE
feat(): #135 add after() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,23 @@ If you don't have a NPM project you can install testy globally using `npm instal
       });
     });
     ```
+* **Running code after every test**: just like many testing frameworks have, there is a way to execute some code after (cleanp) every test in a suite using the `after()` function. Example:
+
+    ```javascript
+    const { suite, test, before, after, assert } = require('@pmoo/testy');
+    
+    suite('using the after() helper', () => {
+      let answer;
+    
+      before(() => {
+        answer = 42;
+      });
+    
+      after(() => {
+        answer = undefined;
+      });
+    });
+    ```
 * **Support for pending tests**: if a test has no body, it will be reported as `[WIP]` and it won't be considered a failure.
 * **Fail-Fast mode**: if enabled, it stops execution in the first test that fails (or has an error). Remaining tests will be marked as skipped.
 * **Run tests and suites in random order**: a good test suite does not depend on a particular order. Enabling this setting is a good way to ensure that.

--- a/README_v4.md
+++ b/README_v4.md
@@ -176,6 +176,23 @@ Please take a look at the `tests` folder, you'll find examples of each possible 
       });
     });
     ```
+* **Running code after every test**: just like many testing frameworks have, there is a way to execute some code after (cleanp) every test in a suite using the `after()` function. Example:
+
+    ```javascript
+    const { suite, test, before, after, assert } = require('@pmoo/testy');
+    
+    suite('using the after() helper', () => {
+      let answer;
+    
+      before(() => {
+        answer = 42;
+      });
+    
+      after(() => {
+        answer = undefined;
+      });
+    });
+    ```
 * **Support for pending tests**: if a test has no body, it will be reported as `[WIP]` and it won't be considered a failure.
 * **Fail-Fast mode**: if enabled, it stops execution in the first test that fails (or has an error). Remaining tests will be marked as skipped.
 * **Run tests and suites in random order**: a good test suite does not depend on a particular order. Enabling this setting is a good way to ensure that.

--- a/README_v4.md
+++ b/README_v4.md
@@ -176,23 +176,6 @@ Please take a look at the `tests` folder, you'll find examples of each possible 
       });
     });
     ```
-* **Running code after every test**: just like many testing frameworks have, there is a way to execute some code after (cleanp) every test in a suite using the `after()` function. Example:
-
-    ```javascript
-    const { suite, test, before, after, assert } = require('@pmoo/testy');
-    
-    suite('using the after() helper', () => {
-      let answer;
-    
-      before(() => {
-        answer = 42;
-      });
-    
-      after(() => {
-        answer = undefined;
-      });
-    });
-    ```
 * **Support for pending tests**: if a test has no body, it will be reported as `[WIP]` and it won't be considered a failure.
 * **Fail-Fast mode**: if enabled, it stops execution in the first test that fails (or has an error). Remaining tests will be marked as skipped.
 * **Run tests and suites in random order**: a good test suite does not depend on a particular order. Enabling this setting is a good way to ensure that.

--- a/lib/test_runner.js
+++ b/lib/test_runner.js
@@ -30,6 +30,10 @@ class TestRunner {
     this.currentSuite().before(beforeBlock);
   }
   
+  registerAfter(afterBlock) {
+    this.currentSuite().after(afterBlock);
+  }
+
   addSuite(suiteToAdd) {
     this.suites().push(suiteToAdd);
     this._setCurrentSuite(suiteToAdd);

--- a/lib/test_suite.js
+++ b/lib/test_suite.js
@@ -30,7 +30,7 @@ class TestSuite {
     if (this._after === undefined)
       this._after = initialization;
     else
-      throw 'There is already a after() block. Please leave just one after() block and run again the tests.';
+      throw 'There is already an after() block. Please leave just one after() block and run again the tests.';
   }
 
   // Executing

--- a/lib/test_suite.js
+++ b/lib/test_suite.js
@@ -10,6 +10,7 @@ class TestSuite {
     this._tests = [];
     this._callbacks = callbacks;
     this._before = undefined;
+    this._after = undefined;
   }
   
   // Initializing / Configuring
@@ -25,6 +26,13 @@ class TestSuite {
       throw 'There is already a before() block. Please leave just one before() block and run again the tests.';
   }
   
+  after(initialization) {
+    if (this._after === undefined)
+      this._after = initialization;
+    else
+      throw 'There is already a after() block. Please leave just one after() block and run again the tests.';
+  }
+
   // Executing
   
   run(failFastMode = FailFast.default(), randomOrderMode = false) {
@@ -116,6 +124,10 @@ class TestSuite {
     this._before && this._before.call();
   }
   
+  _evaluateAfterBlock() {
+    this._after && this._after.call();
+  }
+
   // TODO: reify configuration instead of many boolean flags
   _runTests(failFastMode, randomOrderMode) {
     if (randomOrderMode) {
@@ -125,6 +137,7 @@ class TestSuite {
       this._currentTest = test;
       this._evaluateBeforeBlock();
       test.run(failFastMode);
+      this._evaluateAfterBlock();
     });
   }
 }

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -52,7 +52,21 @@ suite('test suite behavior', () => {
     
     assert
       .that(() => mySuite.after(() => 5 + 6))
-      .raises('There is already a after() block. Please leave just one after() block and run again the tests.');
+      .raises('There is already an after() block. Please leave just one after() block and run again the tests.');
+  });
+
+  test('after hook can be used', () => {
+    let afterTestVar = 10;
+
+    mySuite.before(() => {
+      afterTestVar = 9;
+    });
+    mySuite.after(() => {
+      afterTestVar = 0;
+    });
+    mySuite.addTest(passingTest);
+    runner.run();
+    assert.that(afterTestVar).isEqualTo(0);
   });
 
   test('reporting failures and errors', () => {

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { suite, test, before, assert } = require('../../testy');
+const { suite, test, before, after, assert } = require('../../testy');
 const TestSuite = require('../../lib/test_suite');
 const { Asserter } = require('../../lib/asserter');
 const TestRunner = require('../../lib/test_runner');
@@ -28,6 +28,16 @@ suite('test suite behavior', () => {
     erroredTest = anErroredTest();
     pendingTest = aPendingTest();
   });
+
+  after(() => {
+    runner = undefined;
+    asserter = undefined;
+    mySuite = undefined;
+    passingTest = undefined;
+    failingTest = undefined;
+    erroredTest = undefined;
+    pendingTest = undefined;
+  });
   
   test('more than one before block is not allowed', () => {
     mySuite.before(() => 3 + 4);
@@ -37,6 +47,14 @@ suite('test suite behavior', () => {
       .raises('There is already a before() block. Please leave just one before() block and run again the tests.');
   });
   
+  test('more than one after block is not allowed', () => {
+    mySuite.after(() => 3 + 4);
+    
+    assert
+      .that(() => mySuite.after(() => 5 + 6))
+      .raises('There is already a after() block. Please leave just one after() block and run again the tests.');
+  });
+
   test('reporting failures and errors', () => {
     mySuite.addTest(passingTest);
     mySuite.addTest(failingTest);

--- a/tests/examples/basic_features_test.js
+++ b/tests/examples/basic_features_test.js
@@ -1,10 +1,6 @@
 'use strict';
 
 const { suite, test, before, after, assert } = require('../../testy');
-const TestSuite = require('../../lib/test_suite');
-const { Asserter } = require('../../lib/asserter');
-const TestRunner = require('../../lib/test_runner');
-const { aPassingTest } = require('../support/tests_factory');
 
 suite('testing testy - basic features', () => {
   const circular = {}; circular.yourself = circular;
@@ -19,35 +15,7 @@ suite('testing testy - basic features', () => {
   });
   
   test('before hook can be used', () => assert.areEqual(myVar, 7));
-  test('after hook can be used', () => {
-    const noop = () => {};
-    const emptyRunnerCallbacks = { onFinish: noop };
-    const emptySuiteCallbacks = { onStart: noop, onFinish: noop };
-
-    const newEmptySuite = () => suiteNamed('myTestSuite');
-    const suiteNamed = suiteName => new TestSuite(suiteName, () => {}, emptySuiteCallbacks);
-
-    const asserter = new Asserter(runner);
-    const suite = newEmptySuite();
-    const passingTest = aPassingTest(asserter);
-
-    let afterTestVar = 10;
-
-    const runner = new TestRunner(emptyRunnerCallbacks);
-    runner.addSuite(suite);
-
-    suite.before(() => {
-      afterTestVar = 9;
-    });
-    suite.after(() => {
-      afterTestVar = 0;
-    });
-    suite.addTest(passingTest);
-    runner.run();
-    assert.that(afterTestVar).isEqualTo(0);
-  });
   
-
   test('many assertions', () => {
     assert.areEqual(2, 1 + 1);
     assert.isTrue(true || false);

--- a/testy.js
+++ b/testy.js
@@ -24,6 +24,10 @@ function before(initialization) {
   testRunner.registerBefore(initialization);
 }
 
+function after(initialization) {
+  testRunner.registerAfter(initialization);
+}
+
 class Testy {
   // instance creation
   
@@ -90,4 +94,4 @@ class Testy {
   }
 }
 
-module.exports = { Testy, suite, test, before, assert, fail, pending };
+module.exports = { Testy, suite, test, before, after, assert, fail, pending };


### PR DESCRIPTION
An after(func) hook working in a similar way to before(func). Cannot be defined twice in the same suite.
after() is evaluated right after the execution of a test, no matter the result of it (pass, failure, error)

for review:
- basic_feature_test.js - test after hook can be used, maybe should transfer to behavior test because it share lots of initialising TestSuite boilerplate code that wasn't there before.

