### PR TITLE
[bug#136] throw error when suite or test names are empty

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -123,7 +123,7 @@ class Test {
     }
 
     if(isStringNullOrWhiteSpace(name)) {
-      throw 'Suite and test names cannot be empty'
+      throw 'Suite and test names cannot be empty';
     }
   }
   

--- a/lib/test.js
+++ b/lib/test.js
@@ -2,7 +2,7 @@
 
 const TestResult = require('./test_result');
 const FailFast = require('./fail_fast');
-const { isString, isFunction, isUndefined } = require('./utils');
+const { isString, isStringNullOrWhiteSpace, isFunction, isUndefined } = require('./utils');
 
 class Test {
   constructor(name, body, callbacks) {
@@ -120,6 +120,10 @@ class Test {
   _ensureNameIsValid(name) {
     if (!isString(name)) {
       throw 'Test does not have a valid name';
+    }
+
+    if(isStringNullOrWhiteSpace(name)) {
+      throw 'Suite and test names cannot be empty'
     }
   }
   

--- a/lib/test_suite.js
+++ b/lib/test_suite.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const FailFast = require('./fail_fast');
-const { shuffle, isString, isFunction } = require('./utils');
+const { shuffle, isString, isStringNullOrWhiteSpace, isFunction } = require('./utils');
 
 class TestSuite {
   constructor(name, body, callbacks) {
@@ -93,6 +93,10 @@ class TestSuite {
   _ensureNameIsValid(name) {
     if (!isString(name)) {
       throw 'Suite does not have a valid name';
+    }
+
+    if(isStringNullOrWhiteSpace(name)) {
+      throw 'Suite and test names cannot be empty'
     }
   }
   

--- a/lib/test_suite.js
+++ b/lib/test_suite.js
@@ -96,7 +96,7 @@ class TestSuite {
     }
 
     if(isStringNullOrWhiteSpace(name)) {
-      throw 'Suite and test names cannot be empty'
+      throw 'Suite and test names cannot be empty';
     }
   }
   

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,6 +72,9 @@ const isUndefined = object =>
 const notNullOrUndefined = object =>
   !isUndefined(object) && object !== null;
 
+const isStringNullOrWhiteSpace = string => 
+  string.replace(/\s/g, '').length < 1;
+
 const respondsTo = (object, methodName) =>
   notNullOrUndefined(object) && isFunction(object[methodName]);
 
@@ -95,6 +98,7 @@ module.exports = {
   prettyPrint,
   // types
   isString,
+  isStringNullOrWhiteSpace,
   isFunction,
   isUndefined,
   isRegex,

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -63,6 +63,10 @@ suite('test suite behavior', () => {
   test('a suite cannot be created without a name', () => {
     assert.that(() => new TestSuite()).raises('Suite does not have a valid name');
   });
+
+  test('a suite cannot be created with name empty', () => {
+    assert.that(() => new TestSuite('')).raises('Suite and test names cannot be empty');
+  });
   
   test('a suite cannot be created with a name that is not a string', () => {
     assert.that(() => new TestSuite(new Date())).raises('Suite does not have a valid name');

--- a/tests/core/test_test.js
+++ b/tests/core/test_test.js
@@ -33,4 +33,8 @@ suite('tests behavior', () => {
   test('a test cannot be created with a body that is not a function', () => {
     assert.that(() => new Test('hey', 'ho')).raises('Test does not have a valid body');
   });
+
+  test('a test cannot be created with name empty', () => {
+    assert.that(() => new Test('', undefined)).raises('Suite and test names cannot be empty');
+  });
 });


### PR DESCRIPTION
- add validation for empty string names and throw error

@ngarbezza let me know if this works, I felt it ideally should be `throwing errors` instead of failing as it actually isn't running the test. Also do let me know if you feel this needs unit tests to be added

related to issue #136 