### PR TITLE
Convert to array in Utils to fix iterable params in includes and doesNotInclude Tests

### DIFF
--- a/lib/asserter.js
+++ b/lib/asserter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { prettyPrint, isUndefined, isRegex, notNullOrUndefined, numberOfElements } = require('./utils');
+const { prettyPrint, isUndefined, isRegex, notNullOrUndefined, numberOfElements, builderArrayByType } = require('./utils');
 const EqualityAssertionStrategy = require('./equality_assertion_strategy');
 const TestResult = require('./test_result');
 
@@ -129,7 +129,8 @@ class Assertion extends TestResultReporter {
   // Collection assertions
 
   includes(expectedObject, equalityCriteria) {
-    const resultIsSuccessful = this._actual.find(element =>
+    const convertToArray = builderArrayByType[this._actual.constructor.name];
+    const resultIsSuccessful = convertToArray(this._actual).find(element =>
       this._areConsideredEqual(element, expectedObject, equalityCriteria));
     const failureMessage = `${this.translated('include')} ${prettyPrint(expectedObject)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);
@@ -143,7 +144,8 @@ class Assertion extends TestResultReporter {
   }
 
   doesNotInclude(expectedObject, equalityCriteria) {
-    const resultIsSuccessful = !this._actual.find(element =>
+    const convertToArray = builderArrayByType[this._actual.constructor.name];
+    const resultIsSuccessful = !convertToArray(this._actual).find(element =>
       this._areConsideredEqual(element, expectedObject, equalityCriteria));
     const failureMessage = `${this.translated('not_include')} ${prettyPrint(expectedObject)}`;
     this._reportAssertionResult(resultIsSuccessful, failureMessage);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,6 +94,18 @@ const prettyPrint = object => {
 const numberOfElements = object =>
   Array.from(object).length;
 
+const stringToArray = object => Array.from(object);
+const arrayToArray = object => object;
+const setToArray = object => Array.from(object);
+const mapToArray = object => Array.from(object.values());
+
+const builderArrayByType = {
+  String: stringToArray,
+  Array: arrayToArray,
+  Set: setToArray,
+  Map: mapToArray
+};
+
 module.exports = {
   // comparison on objects
   isCyclic,
@@ -114,4 +126,6 @@ module.exports = {
   // files
   resolvePathFor,
   allFilesMatching,
+  // converts
+  builderArrayByType,
 };

--- a/tests/core/assertions/collection_assertions_test.js
+++ b/tests/core/assertions/collection_assertions_test.js
@@ -169,4 +169,41 @@ suite('collection assertions', () => {
 
     expectFailureDueTo('Expected undefined to be not empty');
   });
+
+  test('includes works with Sets', () => {
+    asserter.that(new Set([42])).includes(42);
+  
+    expectSuccess();
+  });
+
+  test('includes works with Maps', () => {
+    asserter.that(new Map([['key', 42]])).includes(42);
+  
+    expectSuccess();
+  });
+
+  test('includes works with Strings', () => {
+    asserter.that('42').includes('4');
+  
+    expectSuccess();
+  });
+
+  test('doesNotInclude works with Sets', () => {
+    asserter.that(new Set([24])).doesNotInclude(42);
+  
+    expectSuccess();
+  });
+
+  test('doesNotInclude works with Maps', () => {
+    asserter.that(new Map([['key', 24]])).doesNotInclude(42);
+  
+    expectSuccess();
+  });
+
+  test('doesNotInclude works with Strings', () => {
+    asserter.that('24').doesNotInclude('5');
+  
+    expectSuccess();
+  });
+
 });


### PR DESCRIPTION
Fix Issue #130 

- added convert to array in Utils
- added converter to incoming param for assert for method includes & doesNotInclude
- added test for this new feature