### PR TITLE
Fixing Issue #191

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -200,8 +200,8 @@ class Assertion extends TestResultReporter {
       EqualityAssertionStrategy.evaluate(this._actual, expected, criteria);
     const resultIsSuccessful = shouldBeEqual ? comparisonResult : !comparisonResult;
     
-    if (overrideFailureMessage) {
-      this._reportAssertionResult(resultIsSuccessful, overrideFailureMessage);
+    if (isUndefined(comparisonResult)) {
+      this._reportAssertionResult(false, overrideFailureMessage);
     } else {
       const expectationMessageKey = shouldBeEqual ? 'equality_assertion_be_equal_to' : 'equality_assertion_be_not_equal_to';
       const expectationMessage = () => I18nMessage.of(expectationMessageKey, this._actualResultAsString(), prettyPrint(expected));

--- a/lib/equality_assertion_strategy.js
+++ b/lib/equality_assertion_strategy.js
@@ -31,7 +31,7 @@ const BothPartsUndefined = {
   
   evaluate() {
     return {
-      comparisonResult: false,
+      comparisonResult: undefined,
       overrideFailureMessage: () => I18nMessage.of('equality_assertion_failed_due_to_undetermination'),
     };
   },

--- a/tests/core/assertions/equality_assertions_test.js
+++ b/tests/core/assertions/equality_assertions_test.js
@@ -163,4 +163,9 @@ suite('equality assertions', () => {
     const additionalMessage = I18nMessage.of('equality_assertion_failed_due_to_circular_references');
     expectFailureOn(result, I18nMessage.joined([assertionMessage, additionalMessage], ' '));
   });
+
+  test('isNotEqualTo fails if both parts are undefined', () => { 
+    const result = resultOfATestWith(assert => assert.that(undefined).isNotEqualTo(undefined)); 
+    expectFailureOn(result, I18nMessage.of('equality_assertion_failed_due_to_undetermination')); 
+  });
 });


### PR DESCRIPTION
Fixing issue #191 that took place when asserting that two undefined member were not equal. 

The assertion `assert.that(undefined).isNotEqualTo(undefined)` now fails as it should.

Took the same approach taken for the identity assertion `isNotIdenticalTo`.