### PR TITLE
#184 - better error reporting

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -58,7 +58,6 @@ class Configuration {
   }
   
   configureTestRunner(testRunner) {
-    testRunner.useLanguage(this.language());
     testRunner.setFailFastMode(this.failFastMode());
     testRunner.setTestRandomness(this.randomOrder());
   }

--- a/lib/console_ui.js
+++ b/lib/console_ui.js
@@ -63,7 +63,7 @@ class ConsoleUI {
   
   exitWithError(...errorMessages) {
     errorMessages.forEach(errorMessage =>
-      this._formatter.displayError(errorMessage)
+      this._formatter.displayError(errorMessage),
     );
     this._exitWithCode(ConsoleUI.failedExitCode());
   }

--- a/lib/console_ui.js
+++ b/lib/console_ui.js
@@ -61,8 +61,8 @@ class ConsoleUI {
     this._formatter = new Formatter(console, i18n);
   }
   
-  exitWithError(errorMessage) {
-    this._formatter.displayError(errorMessage);
+  exitWithError(...errorMessageLines) {
+    this._formatter.displayError(errorMessageLines.join('\n'));
     this._exitWithCode(ConsoleUI.failedExitCode());
   }
   

--- a/lib/console_ui.js
+++ b/lib/console_ui.js
@@ -11,6 +11,14 @@ class ConsoleUI {
   static failedExitCode() {
     return 1;
   }
+
+  // instance creation
+
+  constructor(process, console) {
+    this._process = process;
+    this._console = console;
+    this.useLanguage(I18n.defaultLanguage());
+  }
   
   // Callbacks for runner/suite/test
   
@@ -48,6 +56,8 @@ class ConsoleUI {
         this._exitWithCode(ConsoleUI.failedExitCode()),
     };
   }
+
+  // application events
   
   start(configuration, paths, runnerBlock) {
     this._formatter.start();
@@ -58,7 +68,7 @@ class ConsoleUI {
   
   useLanguage(language) {
     const i18n = new I18n(language);
-    this._formatter = new Formatter(console, i18n);
+    this._formatter = new Formatter(this._console, i18n);
   }
   
   exitWithError(...errorMessages) {
@@ -67,9 +77,11 @@ class ConsoleUI {
     );
     this._exitWithCode(ConsoleUI.failedExitCode());
   }
+
+  // private
   
   _exitWithCode(exitCode) {
-    process.exit(exitCode);
+    this._process.exit(exitCode);
   }
 }
 

--- a/lib/console_ui.js
+++ b/lib/console_ui.js
@@ -61,8 +61,10 @@ class ConsoleUI {
     this._formatter = new Formatter(console, i18n);
   }
   
-  exitWithError(...errorMessageLines) {
-    this._formatter.displayError(errorMessageLines.join('\n'));
+  exitWithError(...errorMessages) {
+    errorMessages.forEach(errorMessage =>
+      this._formatter.displayError(errorMessage)
+    );
     this._exitWithCode(ConsoleUI.failedExitCode());
   }
   

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -83,7 +83,7 @@ class Formatter {
   // displaying other messages
   
   displayError(message) {
-    this._console.log(`${this._withColor(message, red)}`);
+    this._console.log(`${this._withColor(this._potentiallyInternationalized(message), red)}`);
   }
   
   _displayConfigurationSummary(paths, configuration) {

--- a/lib/test_runner.js
+++ b/lib/test_runner.js
@@ -3,14 +3,12 @@
 const Test = require('./test');
 const TestSuite = require('./test_suite');
 const FailFast = require('./fail_fast');
-const { I18n } = require('./i18n');
 const { shuffle } = require('./utils');
 
 class TestRunner {
   constructor(callbacks) {
     this._suites = [];
     this._callbacks = callbacks;
-    this.useLanguage(I18n.defaultLanguage());
     this.setFailFastMode(FailFast.default());
   }
   
@@ -38,10 +36,6 @@ class TestRunner {
     this._suites.push(suiteToAdd);
     this._setCurrentSuite(suiteToAdd);
     return suiteToAdd;
-  }
-  
-  useLanguage(language) {
-    this._i18n = new I18n(language);
   }
   
   setFailFastMode(failFastMode) {

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -51,7 +51,8 @@
     "invalid_pending_reason": "In order to mark a test as pending, you need to specify a reason.",
     "error_path_not_found": "Error: path %s does not exist.",
     "error_loading_suite": "Error loading suite %s!",
-    "feedback_for_error_loading_suite": "Please check your file contains a valid suite declaration and try again."
+    "feedback_for_error_loading_suite": "Please check your file contains a valid suite declaration and try again.",
+    "error_running_suites": "Error executing the test suites"
   },
   "es": {
     "yes": "sí",
@@ -105,6 +106,7 @@
     "invalid_pending_reason": "Para marcar un test como pendiente, es necesario especificar un motivo.",
     "error_path_not_found": "Error: la ruta %s no existe.",
     "error_loading_suite": "Error cargando el archivo %s!",
-    "feedback_for_error_loading_suite": "Por favor, revisa que tu archivo contenga una declaración de suite válida, e intenta nuevamente."
+    "feedback_for_error_loading_suite": "Por favor, revisa que tu archivo contenga una declaración de suite válida, e intenta nuevamente.",
+    "error_running_suites": "Error ejecutando las suites de test"
   }
 }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -48,7 +48,10 @@
     "fail_fast": "Fail fast",
     "random_order": "Random order",
     "starting_testy": "Starting Testy!",
-    "invalid_pending_reason": "In order to mark a test as pending, you need to specify a reason."
+    "invalid_pending_reason": "In order to mark a test as pending, you need to specify a reason.",
+    "error_path_not_found": "Error: path %s does not exist.",
+    "error_loading_suite": "Error loading suite %s!",
+    "feedback_for_error_loading_suite": "Please check your file contains a valid suite declaration and try again."
   },
   "es": {
     "yes": "sí",
@@ -99,6 +102,9 @@
     "fail_fast": "Fallo rápido",
     "random_order": "Orden aleatorio",
     "starting_testy": "Comenzando a ejecutar Testy!",
-    "invalid_pending_reason": "Para marcar un test como pendiente, es necesario especificar un motivo."
+    "invalid_pending_reason": "Para marcar un test como pendiente, es necesario especificar un motivo.",
+    "error_path_not_found": "Error: la ruta %s no existe.",
+    "error_loading_suite": "Error cargando el archivo %s!",
+    "feedback_for_error_loading_suite": "Por favor, revisa que tu archivo contenga una declaración de suite válida, e intenta nuevamente."
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "testy.js",
   "scripts": {
     "coverage": "npx nyc@latest --reporter=lcov --reporter=text-summary npm test",
-    "open-coverage-report": "xdg-open coverage/lcov-report/index.html",
+    "open-coverage-report": "open coverage/lcov-report/index.html",
     "generate-dependencies-graph": "npx madge -i testy-dependencies.png lib/ bin/",
     "lint": "npx eslint@6.8.0 .",
     "lint-fix": "npx eslint@6.8.0 . --fix",

--- a/tests/ui/console_ui_test.js
+++ b/tests/ui/console_ui_test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { suite, test, before, assert } = require('../../testy');
+
+const ConsoleUI = require('../../lib/console_ui');
+const FakeConsole = require('./fake_console');
+const FakeProcess = require('./fake_process');
+
+suite('Console UI', () => {
+  let fakeProcess, fakeConsole;
+
+  before(() => {
+    fakeProcess = new FakeProcess();
+    fakeConsole = new FakeConsole();
+  });
+
+  test('can exit with error displaying the given message', () => {
+    const console = new ConsoleUI(fakeProcess, fakeConsole);
+    console.exitWithError('a message');
+    assert.that(fakeProcess.lastExitCode()).isEqualTo(ConsoleUI.failedExitCode());
+    assert.that(fakeConsole.messages().length).isEqualTo(1);
+    assert.that(fakeConsole.messages()[0]).matches(/a message/);
+  });
+});

--- a/tests/ui/fake_console.js
+++ b/tests/ui/fake_console.js
@@ -1,0 +1,17 @@
+'use strict';
+
+class FakeConsole {
+  constructor() {
+    this._messages = [];
+  }
+
+  log(message) {
+    this._messages.push(message);
+  }
+
+  messages() {
+    return Array.from(this._messages);
+  }
+}
+
+module.exports = FakeConsole;

--- a/tests/ui/fake_process.js
+++ b/tests/ui/fake_process.js
@@ -1,0 +1,17 @@
+'use strict';
+
+class FakeProcess {
+  constructor() {
+    this._lastExitCode = null;
+  }
+
+  exit(code) {
+    this._lastExitCode = code;
+  }
+
+  lastExitCode() {
+    return this._lastExitCode;
+  }
+}
+
+module.exports = FakeProcess;

--- a/tests/ui/formatter_test.js
+++ b/tests/ui/formatter_test.js
@@ -6,31 +6,22 @@ const { aTestWithBody, aPendingTest } = require('../support/tests_factory');
 
 const Formatter = require('../../lib/formatter');
 const { I18n } = require('../../lib/i18n');
+const FakeConsole = require('./fake_console');
 
 suite('formatter', () => {
-  let formatter, dummyConsole, i18n;
+  let formatter, fakeConsole, i18n;
   
   before(() => {
-    dummyConsole = {
-      _messages: [],
-      
-      log(message) {
-        this._messages.push(message);
-      },
-      
-      messages() {
-        return Array.from(this._messages);
-      },
-    };
+    fakeConsole = new FakeConsole();
   
     i18n = I18n.default();
-    formatter = new Formatter(dummyConsole, i18n);
+    formatter = new Formatter(fakeConsole, i18n);
   });
   
   test('display errors in red', () => {
     formatter.displayError('things happened');
     const expectedErrorMessage = '\x1b[31mthings happened\x1b[0m';
-    assert.that(dummyConsole.messages()).includesExactly(expectedErrorMessage);
+    assert.that(fakeConsole.messages()).includesExactly(expectedErrorMessage);
   });
   
   test('display pending status in yellow including reason', () => {
@@ -40,7 +31,7 @@ suite('formatter', () => {
       formatter.displayPendingResult(test);
       const testResultMessage = '[\u001b[33m\u001b[1mWIP\u001b[0m] \u001b[33mjust a test\u001b[0m';
       const pendingReasonMessage = '  => in a rush';
-      assert.that(dummyConsole.messages()).isEqualTo([testResultMessage, pendingReasonMessage]);
+      assert.that(fakeConsole.messages()).isEqualTo([testResultMessage, pendingReasonMessage]);
     });
   });
   
@@ -51,7 +42,7 @@ suite('formatter', () => {
       formatter.displayErrorResult(test);
       const testResultMessage = '[\u001b[31m\u001b[1mERROR\u001b[0m] \u001b[31mjust a test\u001b[0m';
       const pendingReasonMessage = '  => In order to mark a test as pending, you need to specify a reason.';
-      assert.that(dummyConsole.messages()).isEqualTo([testResultMessage, pendingReasonMessage]);
+      assert.that(fakeConsole.messages()).isEqualTo([testResultMessage, pendingReasonMessage]);
     });
   });
   
@@ -62,7 +53,7 @@ suite('formatter', () => {
       formatter.displayFailureResult(test);
       const testResultMessage = '[\u001b[31m\u001b[1mFAIL\u001b[0m] \u001b[31mjust a test\u001b[0m';
       const failureDetailMessage = '  => I wanted to fail';
-      assert.that(dummyConsole.messages()).isEqualTo([testResultMessage, failureDetailMessage]);
+      assert.that(fakeConsole.messages()).isEqualTo([testResultMessage, failureDetailMessage]);
     });
   });
   
@@ -73,7 +64,7 @@ suite('formatter', () => {
       formatter.displayFailureResult(test);
       const testResultMessage = '[\u001b[31m\u001b[1mFAIL\u001b[0m] \u001b[31mjust a test\u001b[0m';
       const failureDetailMessage = '  => Explicitly failed';
-      assert.that(dummyConsole.messages()).isEqualTo([testResultMessage, failureDetailMessage]);
+      assert.that(fakeConsole.messages()).isEqualTo([testResultMessage, failureDetailMessage]);
     });
   });
   
@@ -83,7 +74,7 @@ suite('formatter', () => {
       runSingleTest(runner, test);
       formatter.displayPendingResult(test);
       const testResultMessage = '[\u001b[33m\u001b[1mWIP\u001b[0m] \u001b[33ma work in progress\u001b[0m';
-      assert.that(dummyConsole.messages()).includesExactly(testResultMessage);
+      assert.that(fakeConsole.messages()).includesExactly(testResultMessage);
     });
   });
 });

--- a/testy.js
+++ b/testy.js
@@ -5,6 +5,7 @@ const TestRunner = require(`${libDir}/test_runner`);
 const { Asserter, FailureGenerator, PendingMarker } = require(`${libDir}/asserter`);
 const ConsoleUI = require(`${libDir}/console_ui`);
 const { allFilesMatching, resolvePathFor } = require(`${libDir}/utils`);
+const { I18nMessage } = require(`${libDir}/i18n`);
 
 const ui = new ConsoleUI();
 const testRunner = new TestRunner(ui.testRunnerCallbacks());
@@ -70,7 +71,7 @@ class Testy {
         this._loadAllFilesIn(path)
       );
     } catch (err) {
-      ui.exitWithError(`Error: ${err.path} does not exist.`);
+      ui.exitWithError(I18nMessage.of('error_path_not_found', err.path));
     }
   }
 
@@ -85,8 +86,8 @@ class Testy {
       require(file)
     } catch (err) {
       ui.exitWithError(
-        `Error loading suite ${file}!`, err.stack,
-        `Please check your file contains a valid suite declaration and try again.`,
+        I18nMessage.of('error_loading_suite', file), err.stack,
+        I18nMessage.of('feedback_for_error_loading_suite'),
       );
     }
   }

--- a/testy.js
+++ b/testy.js
@@ -49,7 +49,7 @@ class Testy {
       try {
         testRunner.run();
       } catch (err) {
-        ui.exitWithError(I18nMessage.of('error_running_suites'), err.stack,);
+        ui.exitWithError(I18nMessage.of('error_running_suites'), err.stack);
       }
     });
     testRunner.finish();
@@ -72,7 +72,7 @@ class Testy {
   _loadAllRequestedFiles() {
     try {
       this._resolvedTestFilesPathsToRun().forEach(path =>
-        this._loadAllFilesIn(path)
+        this._loadAllFilesIn(path),
       );
     } catch (err) {
       ui.exitWithError(I18nMessage.of('error_path_not_found', err.path));
@@ -81,13 +81,13 @@ class Testy {
 
   _loadAllFilesIn(path) {
     allFilesMatching(path, this._testFilesFilter()).forEach(file =>
-      this._loadFileHandlingErrors(file)
+      this._loadFileHandlingErrors(file),
     );
   }
 
   _loadFileHandlingErrors(file) {
     try {
-      require(file)
+      require(file);
     } catch (err) {
       ui.exitWithError(
         I18nMessage.of('error_loading_suite', file), err.stack,

--- a/testy.js
+++ b/testy.js
@@ -67,21 +67,36 @@ class Testy {
   _loadAllRequestedFiles() {
     try {
       this._resolvedTestFilesPathsToRun().forEach(path =>
-        allFilesMatching(path, this._testFilesFilter()).forEach(file =>
-          require(file),
-        ),
+        this._loadAllFilesIn(path)
       );
     } catch (err) {
       ui.exitWithError(`Error: ${err.path} does not exist.`);
     }
   }
-  
+
+  _loadAllFilesIn(path) {
+    allFilesMatching(path, this._testFilesFilter()).forEach(file =>
+      this._loadFileHandlingErrors(file)
+    );
+  }
+
+  _loadFileHandlingErrors(file) {
+    try {
+      require(file)
+    } catch (err) {
+      ui.exitWithError(
+        `Error loading suite ${file}!`, err.stack,
+        `Please check your file contains a valid suite declaration and try again.`,
+      );
+    }
+  }
+
   _testFilesPathsToRun() {
     const requestedPaths = this._requestedPathsToRun();
     return requestedPaths.length > 0 ? requestedPaths : [this._pathForAllTests()];
   }
   
-  _resolvedTestFilesPathsToRun(){
+  _resolvedTestFilesPathsToRun() {
     return this._testFilesPathsToRun().map(path => resolvePathFor(path));
   }
   

--- a/testy.js
+++ b/testy.js
@@ -7,7 +7,7 @@ const ConsoleUI = require(`${libDir}/console_ui`);
 const { allFilesMatching, resolvePathFor } = require(`${libDir}/utils`);
 const { I18nMessage } = require(`${libDir}/i18n`);
 
-const ui = new ConsoleUI();
+const ui = new ConsoleUI(process, console);
 const testRunner = new TestRunner(ui.testRunnerCallbacks());
 const assert = new Asserter(testRunner);
 const fail = new FailureGenerator(testRunner);

--- a/testy.js
+++ b/testy.js
@@ -45,9 +45,13 @@ class Testy {
   run(requestedPaths) {
     this._requestedPaths = requestedPaths;
     this._loadAllRequestedFiles();
-    ui.start(this._configuration, this._testFilesPathsToRun(), () =>
-      testRunner.run(),
-    );
+    ui.start(this._configuration, this._testFilesPathsToRun(), () => {
+      try {
+        testRunner.run();
+      } catch (err) {
+        ui.exitWithError(I18nMessage.of('error_running_suites'), err.stack,);
+      }
+    });
     testRunner.finish();
   }
   


### PR DESCRIPTION
Error handling for two cases:

* errors in a suite file (like compilation errors, or exceptions thrown when loading the file)
* errors inside a suite definition (like a wrong use of `test` or `before`)