### PR TITLE
[#205]: Private field syntax changed (from _field to #field).

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -8,155 +8,156 @@ const { I18nMessage } = require('./i18n');
 const { prettyPrint, isUndefined, isRegex, notNullOrUndefined, numberOfElements, convertToArray } = require('./utils');
 
 class Assertion extends TestResultReporter {
+  #actual;
   constructor(runner, actual) {
     super(runner);
-    this._actual = actual;
+    this.#actual = actual;
   }
   
   // Boolean assertions
   
   isTrue() {
-    this._reportAssertionResult(
-      this._actual === true,
-      () => I18nMessage.of('expectation_be_true', this._actualResultAsString()),
+    this.#reportAssertionResult(
+      this.#actual === true,
+      () => I18nMessage.of('expectation_be_true', this.#actualResultAsString()),
     );
   }
   
   isFalse() {
-    this._reportAssertionResult(
-      this._actual === false,
-      () => I18nMessage.of('expectation_be_false', this._actualResultAsString()),
+    this.#reportAssertionResult(
+      this.#actual === false,
+      () => I18nMessage.of('expectation_be_false', this.#actualResultAsString()),
     );
   }
   
   // Undefined value assertions
   
   isUndefined() {
-    this._reportAssertionResult(
-      isUndefined(this._actual),
-      () => I18nMessage.of('expectation_be_undefined', this._actualResultAsString()),
+    this.#reportAssertionResult(
+      isUndefined(this.#actual),
+      () => I18nMessage.of('expectation_be_undefined', this.#actualResultAsString()),
     );
   }
   
   isNotUndefined() {
-    this._reportAssertionResult(
-      !isUndefined(this._actual),
-      () => I18nMessage.of('expectation_be_defined', this._actualResultAsString()),
+    this.#reportAssertionResult(
+      !isUndefined(this.#actual),
+      () => I18nMessage.of('expectation_be_defined', this.#actualResultAsString()),
     );
   }
   
   // Null value assertions
   
   isNull() {
-    this._reportAssertionResult(
-      this._actual === null,
-      () => I18nMessage.of('expectation_be_null', this._actualResultAsString()),
+    this.#reportAssertionResult(
+      this.#actual === null,
+      () => I18nMessage.of('expectation_be_null', this.#actualResultAsString()),
     );
   }
   
   isNotNull() {
-    this._reportAssertionResult(
-      this._actual !== null,
-      () => I18nMessage.of('expectation_be_not_null', this._actualResultAsString()),
+    this.#reportAssertionResult(
+      this.#actual !== null,
+      () => I18nMessage.of('expectation_be_not_null', this.#actualResultAsString()),
     );
   }
   
   // Equality assertions
   
   isEqualTo(expected, criteria) {
-    this._equalityAssertion(expected, criteria, true);
+    this.#equalityAssertion(expected, criteria, true);
   }
   
   isNotEqualTo(expected, criteria) {
-    this._equalityAssertion(expected, criteria, false);
+    this.#equalityAssertion(expected, criteria, false);
   }
 
   // Identity assertions
 
   isIdenticalTo(expected) {
-    this._identityAssertion(expected, true);
+    this.#identityAssertion(expected, true);
   }
 
   isNotIdenticalTo(expected) {
-    this._identityAssertion(expected, false);
+    this.#identityAssertion(expected, false);
   }
   
   // Collection assertions
   
   includes(expectedObject, equalityCriteria) {
-    const resultIsSuccessful = convertToArray(this._actual).find(element =>
-      this._areConsideredEqual(element, expectedObject, equalityCriteria));
-    const failureMessage = () => I18nMessage.of('expectation_include', this._actualResultAsString(), prettyPrint(expectedObject));
-    this._reportAssertionResult(resultIsSuccessful, failureMessage);
+    const resultIsSuccessful = convertToArray(this.#actual).find(element =>
+      this.#areConsideredEqual(element, expectedObject, equalityCriteria));
+    const failureMessage = () => I18nMessage.of('expectation_include', this.#actualResultAsString(), prettyPrint(expectedObject));
+    this.#reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   isIncludedIn(expectedCollection, equalityCriteria) {
     const resultIsSuccessful = expectedCollection.find(element =>
-      this._areConsideredEqual(element, this._actual, equalityCriteria));
-    const failureMessage = () => I18nMessage.of('expectation_be_included_in', this._actualResultAsString(), prettyPrint(expectedCollection));
-    this._reportAssertionResult(resultIsSuccessful, failureMessage);
+      this.#areConsideredEqual(element, this.#actual, equalityCriteria));
+    const failureMessage = () => I18nMessage.of('expectation_be_included_in', this.#actualResultAsString(), prettyPrint(expectedCollection));
+    this.#reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   doesNotInclude(expectedObject, equalityCriteria) {
-    const resultIsSuccessful = !convertToArray(this._actual).find(element =>
-      this._areConsideredEqual(element, expectedObject, equalityCriteria));
-    const failureMessage = () => I18nMessage.of('expectation_not_include', this._actualResultAsString(), prettyPrint(expectedObject));
-    this._reportAssertionResult(resultIsSuccessful, failureMessage);
+    const resultIsSuccessful = !convertToArray(this.#actual).find(element =>
+      this.#areConsideredEqual(element, expectedObject, equalityCriteria));
+    const failureMessage = () => I18nMessage.of('expectation_not_include', this.#actualResultAsString(), prettyPrint(expectedObject));
+    this.#reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   isNotIncludedIn(expectedCollection, equalityCriteria) {
     const resultIsSuccessful = !expectedCollection.find(element =>
-      this._areConsideredEqual(element, this._actual, equalityCriteria));
-    const failureMessage = () => I18nMessage.of('expectation_be_not_included_in', this._actualResultAsString(), prettyPrint(expectedCollection));
-    this._reportAssertionResult(resultIsSuccessful, failureMessage);
+      this.#areConsideredEqual(element, this.#actual, equalityCriteria));
+    const failureMessage = () => I18nMessage.of('expectation_be_not_included_in', this.#actualResultAsString(), prettyPrint(expectedCollection));
+    this.#reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   includesExactly(...objects) {
-    const resultIsSuccessful = this._haveElementsConsideredEqual(this._actual, objects);
-    const failureMessage = () => I18nMessage.of('expectation_include_exactly', this._actualResultAsString(), prettyPrint(objects));
-    this._reportAssertionResult(resultIsSuccessful, failureMessage);
+    const resultIsSuccessful = this.#haveElementsConsideredEqual(this.#actual, objects);
+    const failureMessage = () => I18nMessage.of('expectation_include_exactly', this.#actualResultAsString(), prettyPrint(objects));
+    this.#reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   isEmpty() {
-    const resultIsSuccessful = numberOfElements(this._actual || {}) === 0 && notNullOrUndefined(this._actual);
-    const failureMessage = () => I18nMessage.of('expectation_be_empty', this._actualResultAsString());
-    this._reportAssertionResult(resultIsSuccessful, failureMessage);
+    const resultIsSuccessful = numberOfElements(this.#actual || {}) === 0 && notNullOrUndefined(this.#actual);
+    const failureMessage = () => I18nMessage.of('expectation_be_empty', this.#actualResultAsString());
+    this.#reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   isNotEmpty() {
-    const setValueWhenUndefined = this._actual || {};
+    const setValueWhenUndefined = this.#actual || {};
     const resultIsSuccessful = numberOfElements(setValueWhenUndefined) > 0;
-    const failureMessage = () => I18nMessage.of('expectation_be_not_empty', this._actualResultAsString());
-    this._reportAssertionResult(resultIsSuccessful, failureMessage);
+    const failureMessage = () => I18nMessage.of('expectation_be_not_empty', this.#actualResultAsString());
+    this.#reportAssertionResult(resultIsSuccessful, failureMessage);
   }
   
   // Exception assertions
   
   raises(errorExpectation) {
     try {
-      this._actual.call();
+      this.#actual.call();
       this.reportFailure(I18nMessage.of('expectation_error', prettyPrint(errorExpectation)));
     } catch (actualError) {
-      const assertionPassed = this._checkIfErrorMatchesExpectation(errorExpectation, actualError);
+      const assertionPassed = this.#checkIfErrorMatchesExpectation(errorExpectation, actualError);
       const errorMessage = () => I18nMessage.of('expectation_different_error', prettyPrint(errorExpectation), prettyPrint(actualError));
-      this._reportAssertionResult(assertionPassed, errorMessage);
+      this.#reportAssertionResult(assertionPassed, errorMessage);
     }
   }
   
   doesNotRaise(notExpectedError) {
     try {
-      this._actual.call();
+      this.#actual.call();
       this.reportSuccess();
     } catch (actualError) {
-      const errorCheck = this._checkIfErrorMatchesExpectation(notExpectedError, actualError);
+      const errorCheck = this.#checkIfErrorMatchesExpectation(notExpectedError, actualError);
       const failureMessage = () => I18nMessage.of('expectation_no_error', prettyPrint(actualError));
-      this._reportAssertionResult(!errorCheck, failureMessage);
+      this.#reportAssertionResult(!errorCheck, failureMessage);
     }
   }
   
   doesNotRaiseAnyErrors() {
     try {
-      this._actual.call();
+      this.#actual.call();
       this.reportSuccess(true);
     } catch (error) {
       this.reportFailure(I18nMessage.of('expectation_no_errors', prettyPrint(error)));
@@ -166,63 +167,63 @@ class Assertion extends TestResultReporter {
   // Numeric assertions
   
   isNearTo(number, precisionDigits = 4) {
-    const result = Number.parseFloat((this._actual).toFixed(precisionDigits)) === number;
-    const failureMessage = () => I18nMessage.of('expectation_be_near_to', this._actualResultAsString(), number.toString(), precisionDigits.toString());
-    this._reportAssertionResult(result, failureMessage);
+    const result = Number.parseFloat((this.#actual).toFixed(precisionDigits)) === number;
+    const failureMessage = () => I18nMessage.of('expectation_be_near_to', this.#actualResultAsString(), number.toString(), precisionDigits.toString());
+    this.#reportAssertionResult(result, failureMessage);
   }
   
   // String assertions
   
   matches(regex) {
-    const result = this._actual.match(regex);
-    const failureMessage = () => I18nMessage.of('expectation_match_regex', this._actualResultAsString(), regex);
-    this._reportAssertionResult(result, failureMessage);
+    const result = this.#actual.match(regex);
+    const failureMessage = () => I18nMessage.of('expectation_match_regex', this.#actualResultAsString(), regex);
+    this.#reportAssertionResult(result, failureMessage);
   }
   
   // Private
 
-  _identityAssertion(expected, shouldBeIdentical) {
+  #identityAssertion(expected, shouldBeIdentical) {
     const { comparisonResult, overrideFailureMessage } =
-      IdentityAssertionStrategy.evaluate(this._actual, expected);
+      IdentityAssertionStrategy.evaluate(this.#actual, expected);
     const resultIsSuccessful = shouldBeIdentical ? comparisonResult : !comparisonResult;
 
     if (isUndefined(comparisonResult)) {
-      this._reportAssertionResult(false, overrideFailureMessage);
+      this.#reportAssertionResult(false, overrideFailureMessage);
     } else {
       const expectationMessageKey = shouldBeIdentical ? 'identity_assertion_be_identical_to' : 'identity_assertion_be_not_identical_to';
-      const expectationMessage = () => I18nMessage.of(expectationMessageKey, this._actualResultAsString(), prettyPrint(expected));
-      this._reportAssertionResult(resultIsSuccessful, expectationMessage);
+      const expectationMessage = () => I18nMessage.of(expectationMessageKey, this.#actualResultAsString(), prettyPrint(expected));
+      this.#reportAssertionResult(resultIsSuccessful, expectationMessage);
     }
   }
   
-  _equalityAssertion(expected, criteria, shouldBeEqual) {
+  #equalityAssertion(expected, criteria, shouldBeEqual) {
     const { comparisonResult, additionalFailureMessage, overrideFailureMessage } =
-      EqualityAssertionStrategy.evaluate(this._actual, expected, criteria);
+      EqualityAssertionStrategy.evaluate(this.#actual, expected, criteria);
     const resultIsSuccessful = shouldBeEqual ? comparisonResult : !comparisonResult;
     
     if (isUndefined(comparisonResult)) {
-      this._reportAssertionResult(false, overrideFailureMessage);
+      this.#reportAssertionResult(false, overrideFailureMessage);
     } else {
       const expectationMessageKey = shouldBeEqual ? 'equality_assertion_be_equal_to' : 'equality_assertion_be_not_equal_to';
-      const expectationMessage = () => I18nMessage.of(expectationMessageKey, this._actualResultAsString(), prettyPrint(expected));
+      const expectationMessage = () => I18nMessage.of(expectationMessageKey, this.#actualResultAsString(), prettyPrint(expected));
       const finalMessage = () => I18nMessage.joined([expectationMessage.call(), additionalFailureMessage.call()], ' ');
-      this._reportAssertionResult(resultIsSuccessful, finalMessage);
+      this.#reportAssertionResult(resultIsSuccessful, finalMessage);
     }
   }
   
-  _areConsideredEqual(objectOne, objectTwo, equalityCriteria) {
+  #areConsideredEqual(objectOne, objectTwo, equalityCriteria) {
     return EqualityAssertionStrategy.evaluate(objectOne, objectTwo, equalityCriteria).comparisonResult;
   }
   
-  _checkIfErrorMatchesExpectation(errorExpectation, actualError) {
+  #checkIfErrorMatchesExpectation(errorExpectation, actualError) {
     if (isRegex(errorExpectation)) {
       return errorExpectation.test(actualError);
     } else {
-      return this._areConsideredEqual(actualError, errorExpectation);
+      return this.#areConsideredEqual(actualError, errorExpectation);
     }
   }
   
-  _reportAssertionResult(wasSuccess, failureMessage) {
+  #reportAssertionResult(wasSuccess, failureMessage) {
     if (wasSuccess) {
       this.reportSuccess();
     } else {
@@ -230,11 +231,11 @@ class Assertion extends TestResultReporter {
     }
   }
   
-  _actualResultAsString() {
-    return prettyPrint(this._actual);
+  #actualResultAsString() {
+    return prettyPrint(this.#actual);
   }
   
-  _haveElementsConsideredEqual(collectionOne, collectionTwo) {
+  #haveElementsConsideredEqual(collectionOne, collectionTwo) {
     const collectionOneArray = Array.from(collectionOne);
     const collectionTwoArray = Array.from(collectionTwo);
     if (collectionOneArray.length !== collectionTwoArray.length) {
@@ -242,9 +243,9 @@ class Assertion extends TestResultReporter {
     }
     for (let index = 0; index < collectionOne.length; index++) {
       const includedInOne = collectionOne.find(element =>
-        this._areConsideredEqual(element, collectionTwoArray[index]));
+        this.#areConsideredEqual(element, collectionTwoArray[index]));
       const includedInTwo = collectionTwo.find(element =>
-        this._areConsideredEqual(element, collectionOneArray[index]));
+        this.#areConsideredEqual(element, collectionOneArray[index]));
       if (!includedInOne || !includedInTwo) {
         return false;
       }

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -6,6 +6,9 @@ const CONFIGURATION_FILE_NAME = '.testyrc.json';
 
 class Configuration {
   
+  #userConfigurationOptions;
+  #defaultConfigurationOptions;
+  #configurationOptions;
   // instance creation
   
   static current() {
@@ -20,15 +23,15 @@ class Configuration {
   }
   
   constructor(userConfiguration, defaultConfiguration) {
-    this._userConfigurationOptions = userConfiguration;
-    this._defaultConfigurationOptions = defaultConfiguration;
-    this._initializeOptions();
+    this.#userConfigurationOptions = userConfiguration;
+    this.#defaultConfigurationOptions = defaultConfiguration;
+    this.#initializeOptions();
   }
   
   // accessing configuration parameters
   
   directory() {
-    return this._configurationOptions.directory;
+    return this.#configurationOptions.directory;
   }
   
   filter() {
@@ -36,19 +39,19 @@ class Configuration {
   }
 
   filterRaw() {
-    return this._configurationOptions.filter;
+    return this.#configurationOptions.filter;
   }
   
   language() {
-    return this._configurationOptions.language;
+    return this.#configurationOptions.language;
   }
   
   failFastMode() {
-    return new FailFast(this._configurationOptions.failFast);
+    return new FailFast(this.#configurationOptions.failFast);
   }
   
   randomOrder() {
-    return this._configurationOptions.randomOrder;
+    return this.#configurationOptions.randomOrder;
   }
   
   // configuring
@@ -64,8 +67,8 @@ class Configuration {
   
   // initialization
   
-  _initializeOptions() {
-    this._configurationOptions = { ...this._defaultConfigurationOptions, ...this._userConfigurationOptions };
+  #initializeOptions() {
+    this.#configurationOptions = { ...this.#defaultConfigurationOptions, ...this.#userConfigurationOptions };
   }
 }
 

--- a/lib/console_ui.js
+++ b/lib/console_ui.js
@@ -4,6 +4,11 @@ const { I18n } = require('./i18n');
 const Formatter = require('./formatter');
 
 class ConsoleUI {
+
+  #process;
+  #console;
+  #formatter
+
   static successfulExitCode() {
     return 0;
   }
@@ -15,8 +20,8 @@ class ConsoleUI {
   // instance creation
 
   constructor(process, console) {
-    this._process = process;
-    this._console = console;
+    this.#process = process;
+    this.#console = console;
     this.useLanguage(I18n.defaultLanguage());
   }
   
@@ -25,63 +30,63 @@ class ConsoleUI {
   testCallbacks() {
     return {
       whenPending: test =>
-        this._formatter.displayPendingResult(test),
+        this.#formatter.displayPendingResult(test),
       whenSkipped: test =>
-        this._formatter.displaySkippedResult(test),
+        this.#formatter.displaySkippedResult(test),
       whenSuccess: test =>
-        this._formatter.displaySuccessResult(test),
+        this.#formatter.displaySuccessResult(test),
       whenFailed: test =>
-        this._formatter.displayFailureResult(test),
+        this.#formatter.displayFailureResult(test),
       whenErrored: test =>
-        this._formatter.displayErrorResult(test),
+        this.#formatter.displayErrorResult(test),
     };
   }
   
   suiteCallbacks() {
     return {
       onStart: suite =>
-        this._formatter.displaySuiteStart(suite),
+        this.#formatter.displaySuiteStart(suite),
       onFinish: suite =>
-        this._formatter.displaySuiteEnd(suite),
+        this.#formatter.displaySuiteEnd(suite),
     };
   }
   
   testRunnerCallbacks() {
     return {
       onFinish: runner =>
-        this._formatter.displayRunnerEnd(runner),
+        this.#formatter.displayRunnerEnd(runner),
       onSuccess: _runner =>
-        this._exitWithCode(ConsoleUI.successfulExitCode()),
+        this.#exitWithCode(ConsoleUI.successfulExitCode()),
       onFailure: _runner =>
-        this._exitWithCode(ConsoleUI.failedExitCode()),
+        this.#exitWithCode(ConsoleUI.failedExitCode()),
     };
   }
 
   // application events
   
   start(configuration, paths, runnerBlock) {
-    this._formatter.start();
-    this._formatter.displayInitialInformation(configuration, paths);
+    this.#formatter.start();
+    this.#formatter.displayInitialInformation(configuration, paths);
     runnerBlock.call();
-    this._formatter.end();
+    this.#formatter.end();
   }
   
   useLanguage(language) {
     const i18n = new I18n(language);
-    this._formatter = new Formatter(this._console, i18n);
+    this.#formatter = new Formatter(this.#console, i18n);
   }
   
   exitWithError(...errorMessages) {
     errorMessages.forEach(errorMessage =>
-      this._formatter.displayError(errorMessage),
+      this.#formatter.displayError(errorMessage),
     );
-    this._exitWithCode(ConsoleUI.failedExitCode());
+    this.#exitWithCode(ConsoleUI.failedExitCode());
   }
 
   // private
   
-  _exitWithCode(exitCode) {
-    this._process.exit(exitCode);
+  #exitWithCode(exitCode) {
+    this.#process.exit(exitCode);
   }
 }
 


### PR DESCRIPTION
### Refactor

Changed private field syntax in some of the files. (PR1)

syntax: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_With_Private_Class_Features,

Private fields syntax changed in these files:
1. assertion.js
2. configuration.js
3. console_ui.js