### PR TITLE
:boom: drop support for Node 8.x and 10.x (fixes #214)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v1

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - run: npm ci
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm publish
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+* :boom: Node 12.x or higher is required. Support for Node 8.x and 10.x has dropped.
+There is now an architectural decision record to specify how support will work
+going forward. [#214](https://github.com/ngarbezza/testy/issues/214)
+
 ### Added
 
 * [[feature] isIdenticalTo() / isNotIdenticalTo() assertions](https://github.com/ngarbezza/testy/issues/182), thank you @franciscojaimesfreyre, for your first contribution!

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ A very simple JS testing framework, for educational purposes. Live at npm at [@p
 `npm install --save-dev @pmoo/testy` (if you use [npm](https://www.npmjs.com/)) \
 `yarn add --dev @pmoo/testy` (if you use [yarn](https://classic.yarnpkg.com/en/))
 
-**Supported Node versions**: 8.x or higher
+**Supported Node versions**: 12.x or higher (versions with active and security support
+listed [here](https://endoflife.date/nodejs))
 
 ## Usage
 

--- a/README_es.md
+++ b/README_es.md
@@ -30,7 +30,8 @@ Una simple herramienta de testeo en Javascript, para propósitos educativos. Dis
 `npm install --save-dev @pmoo/testy` (si utilizas [npm](https://www.npmjs.com/)) \
 `yarn add --dev @pmoo/testy` (si utilizas [yarn](https://classic.yarnpkg.com/en/))
 
-**Versiones de Node soportadas**: 8.x o mayor
+**Versiones de Node soportadas**: 12.x o mayor (todas las versiones con soporte activo
+o de seguridad listadas [aquí](https://endoflife.date/nodejs))
 
 ## Uso
 

--- a/doc/decisions/0007-support-node-versions-with-at-least-security-updates.md
+++ b/doc/decisions/0007-support-node-versions-with-at-least-security-updates.md
@@ -1,0 +1,21 @@
+# 7. Support Node versions with at least security updates
+
+Date: 2021-10-08
+
+## Status
+
+Accepted
+
+## Context
+
+Making clear which versions are supported and how this will be updated as time passes.
+
+## Decision
+
+Only support Node versions with active and security support. Do not support newer, unstable versions.
+We can use [endoflife.date](https://endoflife.date/nodejs) as a reference. Example: at the moment
+of this decision, only Node 12, 14 and 16 should be supported.
+
+## Consequences
+
+- Everytime we drop support of a major Node version, we need to make a major release.


### PR DESCRIPTION
## What

Dropping support for Node 8 and 10, add support for Node 16

## Link to issue(s)

Issue(s) this PR fixes. Example:

#214 

## Contribution guidelines

- [x] I have read the Contributing guidelines
