### PR TITLE
🐛 fix #203 assert failFast config is a boolean

### DIFF
--- a/lib/config/fail_fast.js
+++ b/lib/config/fail_fast.js
@@ -1,5 +1,5 @@
+import { isBoolean } from '../utils.js';
 'use strict';
-
 export class FailFast {
   static default() {
     return this.disabled();
@@ -13,7 +13,20 @@ export class FailFast {
     return new this(true);
   }
 
+  static invalidEnableTypeErrorMessage(){
+    return 'Expected a boolean value for failFast configuration';
+  }
+
+  // assertions
+
+  assertIsValidFailFastMode(enabled) {
+    if (!isBoolean(enabled)){
+      throw new Error(FailFast.invalidEnableTypeErrorMessage());
+    }
+  }
+
   constructor(enabled) {
+    this.assertIsValidFailFastMode(enabled);
     this._enabled = enabled;
     this._occurred = false;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,6 +71,9 @@ const shuffle = array => {
   return array;
 };
 
+const isBoolean = object => 
+  typeof object === 'boolean';
+
 const isString = object =>
   typeof object === 'string';
 
@@ -147,6 +150,7 @@ export {
   // printing
   prettyPrint,
   // types
+  isBoolean,
   isString,
   isStringWithContent,
   isFunction,

--- a/tests/core/configuration_test.js
+++ b/tests/core/configuration_test.js
@@ -46,4 +46,11 @@ suite('Configuration parameters', () => {
     const userCustomizedConfiguration = new Configuration(userOptions, defaultConfiguration);
     assert.areEqual(userCustomizedConfiguration.directory(), 'test_files_here');
   });
+
+  test('there is an error when failFast option is not a boolean', () => {
+    const userOptions = { failFast: 'I AM AN INVALID VALUE' };
+    const userCustomizedConfiguration = new Configuration(userOptions, defaultConfiguration);
+    assert.that(() => userCustomizedConfiguration.failFastMode())
+    .raises(new Error(FailFast.invalidEnableTypeErrorMessage()));
+  });
 });

--- a/tests/core/configuration_test.js
+++ b/tests/core/configuration_test.js
@@ -51,6 +51,6 @@ suite('Configuration parameters', () => {
     const userOptions = { failFast: 'I AM AN INVALID VALUE' };
     const userCustomizedConfiguration = new Configuration(userOptions, defaultConfiguration);
     assert.that(() => userCustomizedConfiguration.failFastMode())
-    .raises(new Error(FailFast.invalidEnableTypeErrorMessage()));
+      .raises(new Error(FailFast.invalidEnableTypeErrorMessage()));
   });
 });

--- a/tests/core/fail_fast_test.js
+++ b/tests/core/fail_fast_test.js
@@ -26,4 +26,12 @@ suite('fail fast behavior', () => {
 
     assert.isFalse(failFast.hasFailed());
   });
+
+  test('when created, throws an error if failFastMode is not of boolean type', () => {
+    const failFastMode = 'I AM AN INVALID VALUE'
+
+    assert.that(() => new FailFast(failFastMode)).raises(
+      new Error(FailFast.invalidEnableTypeErrorMessage())
+    );
+  })
 });

--- a/tests/core/fail_fast_test.js
+++ b/tests/core/fail_fast_test.js
@@ -28,10 +28,9 @@ suite('fail fast behavior', () => {
   });
 
   test('when created, throws an error if failFastMode is not of boolean type', () => {
-    const failFastMode = 'I AM AN INVALID VALUE'
+    const failFastMode = 'I AM AN INVALID VALUE';
 
-    assert.that(() => new FailFast(failFastMode)).raises(
-      new Error(FailFast.invalidEnableTypeErrorMessage())
-    );
-  })
+    assert.that(() => new FailFast(failFastMode))
+      .raises(new Error(FailFast.invalidEnableTypeErrorMessage()));
+  });
 });

--- a/tests/utils_test.js
+++ b/tests/utils_test.js
@@ -5,6 +5,7 @@ import { assert, suite, test } from '../lib/testy.js';
 import {
   detectUserCallingLocation,
   errorDetailOf,
+  isBoolean,
   isCyclic, isEmpty,
   isRegex, isStringWithContent,
   isUndefined,
@@ -169,5 +170,16 @@ suite('utility functions', () => {
 
   test('detectUserCallingLocation() reports a valid location', () => {
     assert.that(detectUserCallingLocation()).matches(sourceCodeLocationRegex);
+  });
+
+  test('isBoolean() returns true on true and false booleans', () => {
+    assert.isTrue(isBoolean(true));
+    assert.isTrue(isBoolean(false));
+  });
+
+  test('isBoolean() returns false on non boolean types', () => {
+    assert.isFalse(isBoolean(3));
+    assert.isFalse(isBoolean(undefined));
+    assert.isFalse(isBoolean('I AM AN INVALID VALUE'));
   });
 });


### PR DESCRIPTION
Fix #203 Failfast configuration must be a valid boolean.