### PR TITLE
Bugfix : Running mulitple (> 3) test suites with async tests results in suite mixup and test failure #275

### DIFF
--- a/lib/core/test.js
+++ b/lib/core/test.js
@@ -25,9 +25,10 @@ export class Test {
   // Execution
 
   async run(context) {
+    const state = { isRunning: true };
     await Promise.race([
-      this.#timeoutThreshold(context.testExecutionTimeoutMs),
-      TestResult.evaluate(this, context),
+      this.#timeoutThreshold(context.testExecutionTimeoutMs, state),
+      TestResult.evaluate(this, context).then(_ => state.isRunning = false)
     ]);
   }
 
@@ -150,11 +151,13 @@ export class Test {
     }
   }
 
-  #timeoutThreshold(timeoutMs) {
+  #timeoutThreshold(timeoutMs, state) {
     return new Promise(resolve => {
       setTimeout(() => {
-        this.setResult(TestResult.error(I18nMessage.of('reached_timeout_error', timeoutMs)));
-        this.finishWithError();
+        if (state.isRunning) {
+          this.setResult(TestResult.error(I18nMessage.of('reached_timeout_error', timeoutMs)));
+          this.finishWithError();
+        }
         // This is resolve() and not reject() because we want other tests to be executed.
         // There was an error in terms of the test itself, but there was not an error in terms of Testy's execution.
         resolve();

--- a/lib/core/test.js
+++ b/lib/core/test.js
@@ -28,7 +28,7 @@ export class Test {
     const state = { isRunning: true };
     await Promise.race([
       this.#timeoutThreshold(context.testExecutionTimeoutMs, state),
-      TestResult.evaluate(this, context).then(result => state.isRunning = false),
+      TestResult.evaluate(this, context).then(_result => state.isRunning = false),
     ]);
   }
 

--- a/lib/core/test.js
+++ b/lib/core/test.js
@@ -28,7 +28,7 @@ export class Test {
     const state = { isRunning: true };
     await Promise.race([
       this.#timeoutThreshold(context.testExecutionTimeoutMs, state),
-      TestResult.evaluate(this, context).then(_ => state.isRunning = false)
+      TestResult.evaluate(this, context).then(result => state.isRunning = false),
     ]);
   }
 

--- a/tests/core/test_test.js
+++ b/tests/core/test_test.js
@@ -1,9 +1,9 @@
 'use strict';
 
 import { assert, suite, test } from '../../lib/testy.js';
-import { aPassingTest, aTestWithBody, aTestWithNoAssertions } from '../support/tests_factory.js';
+import { aPassingTest, aTestWithBody, aTestWithNoAssertions, aTestRunningFor } from '../support/tests_factory.js';
 import { resultOfASuiteWith, resultOfATestWith, withRunner } from '../support/runner_helpers.js';
-import { expectErrorOn, expectFailureOn } from '../support/assertion_helpers.js';
+import {expectErrorOn, expectFailureOn, expectSuccess} from '../support/assertion_helpers.js';
 
 import { Test } from '../../lib/core/test.js';
 import { I18nMessage } from '../../lib/i18n/i18n_messages.js';
@@ -93,6 +93,16 @@ suite('tests behavior', () => {
     });
 
     expectErrorOn(result, I18nMessage.of('reached_timeout_error', 50), '');
+  });
+
+  test('a test does not fail by timeout when previous timeout promise resolves', async() => {
+    await withRunner(async (runner, asserter) => {
+      const test = aTestRunningFor(40, asserter);
+      let result = await resultOfASuiteWith(runner, test);
+      expectSuccess(result);
+      result = await resultOfASuiteWith(runner, test);
+      expectSuccess(result);
+    });
   });
 
   test('a test fails by timeout if the before() block fails by timeout', async() => {

--- a/tests/support/tests_factory.js
+++ b/tests/support/tests_factory.js
@@ -31,6 +31,13 @@ const aPendingTest = () =>
 const aTestWithNoAssertions = () =>
   aTestWithBody(() => 1 + 2);
 
+const aTestRunningFor = (millis, asserter) =>
+  new Test('sleepFor', async () => {
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+    await sleep(millis);
+    asserter.isTrue(true);
+  }, emptyTestCallbacks);
+
 const aTestWithBody = body =>
   new Test('just a test', body, emptyTestCallbacks);
 
@@ -41,5 +48,6 @@ export {
   anErroredTest,
   aPendingTest,
   aTestWithNoAssertions,
+  aTestRunningFor,
   emptyTestCallbacks,
 };


### PR DESCRIPTION
## What

Running multiple test suites or tests within a suite will result in a test failure when the first timeout promise resolves

## Link to issue(s)

* [[bug] Running mulitple (> 3) test suites with async tests results in suite mixup and test failure](https://github.com/ngarbezza/testy/issues/275)

## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)
