### PR TITLE
[Feature ✨] Skipping suites

### DIFF
--- a/lib/core/test.js
+++ b/lib/core/test.js
@@ -55,7 +55,7 @@ export class Test {
 
   markSkipped(skippedResult) {
     this.setResult(skippedResult);
-    this.#callbacks.whenSkipped(this);
+    this.finishWithSkippedStatus();
   }
 
   markExplicitlySkipped(explicitlySkippedResult) {

--- a/lib/core/test_suite.js
+++ b/lib/core/test_suite.js
@@ -103,6 +103,7 @@ export class TestSuite {
   // Executing
 
   async run(context) {
+    console.log(this.isSkipped());
     if (!this.isSkipped()) {
       this.#callbacks.onStart(this);
       this.#evaluateSuiteDefinition();

--- a/lib/core/test_suite.js
+++ b/lib/core/test_suite.js
@@ -94,10 +94,15 @@ export class TestSuite {
   isSkipped() {
     return this.#isSkipped;
   }
+
+  #skipAllTests() {
+    this.tests().forEach(test => test.skip());
+  }
+  
   // Executing
 
   async run(context) {
-    if(!this.isSkipped()) {
+    if (!this.isSkipped()) {
       this.#callbacks.onStart(this);
       this.#evaluateSuiteDefinition();
       await this.#runTests(context);
@@ -218,9 +223,5 @@ export class TestSuite {
       // eslint-disable-next-line no-await-in-loop
       await test.run(context);
     }
-  }
-
-  #skipAllTests() {
-    this.tests().forEach(test => test.skip())
   }
 }

--- a/lib/core/test_suite.js
+++ b/lib/core/test_suite.js
@@ -13,6 +13,7 @@ export class TestSuite {
   #callbacks;
   #before;
   #after;
+  #isSkipped;
 
   static BEFORE_HOOK_NAME = 'before';
   static AFTER_HOOK_NAME = 'after';
@@ -44,6 +45,7 @@ export class TestSuite {
     this.#callbacks = callbacks;
     this.#before = undefined;
     this.#after = undefined;
+    this.#isSkipped = false;
   }
 
   // Initializing / Configuring
@@ -84,13 +86,23 @@ export class TestSuite {
     this.#after = releasingBlock;
   }
 
+  // Skipping
+  skip() { 
+    this.#skipAllTests();
+  }
+
+  isSkipped() {
+    return this.#isSkipped;
+  }
   // Executing
 
   async run(context) {
-    this.#callbacks.onStart(this);
-    this.#evaluateSuiteDefinition();
-    await this.#runTests(context);
-    this.#callbacks.onFinish(this);
+    if(!this.isSkipped()) {
+      this.#callbacks.onStart(this);
+      this.#evaluateSuiteDefinition();
+      await this.#runTests(context);
+      this.#callbacks.onFinish(this);
+    }
   }
 
   // Counting
@@ -206,5 +218,9 @@ export class TestSuite {
       // eslint-disable-next-line no-await-in-loop
       await test.run(context);
     }
+  }
+
+  #skipAllTests() {
+    this.tests().forEach(test => test.skip())
   }
 }

--- a/lib/core/test_suite.js
+++ b/lib/core/test_suite.js
@@ -87,7 +87,8 @@ export class TestSuite {
   }
 
   // Skipping
-  skip() { 
+  skip() {
+    this.#isSkipped = true; 
     this.#skipAllTests();
   }
 
@@ -98,7 +99,7 @@ export class TestSuite {
   #skipAllTests() {
     this.tests().forEach(test => test.skip());
   }
-  
+
   // Executing
 
   async run(context) {

--- a/lib/core/test_suite.js
+++ b/lib/core/test_suite.js
@@ -88,8 +88,8 @@ export class TestSuite {
 
   // Skipping
   skip() {
-    this.#isSkipped = true; 
-    this.#skipAllTests();
+    this.#isSkipped = true;
+    // this.#skipAllTests();
   }
 
   isSkipped() {
@@ -97,18 +97,23 @@ export class TestSuite {
   }
 
   #skipAllTests() {
-    this.tests().forEach(test => test.skip());
+    this.tests().forEach(test => {
+      test.skip();
+      test.finishWithSkippedStatus();
+    });
   }
 
   // Executing
 
   async run(context) {
-    if (!this.isSkipped()) {
-      this.#callbacks.onStart(this);
-      this.#evaluateSuiteDefinition();
+    this.#callbacks.onStart(this);
+    this.#evaluateSuiteDefinition();
+    if (this.isSkipped()) {
+      this.#skipAllTests();
+    } else {
       await this.#runTests(context);
-      this.#callbacks.onFinish(this);
     }
+    this.#callbacks.onFinish(this);
   }
 
   // Counting

--- a/lib/core/test_suite.js
+++ b/lib/core/test_suite.js
@@ -103,7 +103,6 @@ export class TestSuite {
   // Executing
 
   async run(context) {
-    console.log(this.isSkipped());
     if (!this.isSkipped()) {
       this.#callbacks.onStart(this);
       this.#evaluateSuiteDefinition();

--- a/lib/core/test_suite.js
+++ b/lib/core/test_suite.js
@@ -89,7 +89,6 @@ export class TestSuite {
   // Skipping
   skip() {
     this.#isSkipped = true;
-    // this.#skipAllTests();
   }
 
   isSkipped() {

--- a/lib/testy.js
+++ b/lib/testy.js
@@ -79,7 +79,7 @@ function test(name, testBody) {
  * @returns {void}
  */
 function suite(name, suiteBody) {
-  testRunner.registerSuite(name, suiteBody, ui.suiteCallbacks());
+  return testRunner.registerSuite(name, suiteBody, ui.suiteCallbacks());
 }
 
 /**

--- a/lib/testy.js
+++ b/lib/testy.js
@@ -76,7 +76,7 @@ function test(name, testBody) {
  *
  * @param {!string} name how you would like to call the suite. Non-empty string.
  * @param {!function} suiteBody the suite definition, written as a zero-argument function.
- * @returns {void}
+ * @returns {TestSuite}
  */
 function suite(name, suiteBody) {
   return testRunner.registerSuite(name, suiteBody, ui.suiteCallbacks());

--- a/lib/ui/formatter.js
+++ b/lib/ui/formatter.js
@@ -3,7 +3,7 @@ import { isEmpty, isString } from '../utils.js';
 // Colors and emphasis
 const off = '\x1b[0m';
 const bold = '\x1b[1m';
-const grey = '\x1b[30m';
+const cyan = '\x1b[36m';
 const red = '\x1b[31m';
 const green = '\x1b[32m';
 const yellow = '\x1b[33m';
@@ -66,7 +66,7 @@ export class Formatter {
   }
 
   displaySkippedResult(test) {
-    this.#displayResult(this.#translated('skip'), test, grey);
+    this.#displayResult(this.#translated('skip'), test, cyan);
   }
 
   displaySuccessResult(test) {

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -22,183 +22,185 @@ suite('test suite behavior', () => {
     });
   });
 
-  test('it is possible to retrieve the suite name', () => {
-    const testSuite = new TestSuite('my cool behavior', () => {});
+  // test('it is possible to retrieve the suite name', () => {
+  //   const testSuite = new TestSuite('my cool behavior', () => {});
 
-    assert.that(testSuite.name()).isEqualTo('my cool behavior');
-  });
+  //   assert.that(testSuite.name()).isEqualTo('my cool behavior');
+  // });
 
-  test('more than one before block is not allowed', () => {
-    mySuite.before(() => 3 + 4);
+  // test('more than one before block is not allowed', () => {
+  //   mySuite.before(() => 3 + 4);
 
-    assert
-      .that(() => mySuite.before(() => 5 + 6))
-      .raises(new Error('There is already a before() block. Please leave just one before() block and run again the tests.'));
-  });
+  //   assert
+  //     .that(() => mySuite.before(() => 5 + 6))
+  //     .raises(new Error('There is already a before() block. Please leave just one before() block and run again the tests.'));
+  // });
 
-  test('a before() hook with no function is considered invalid', () => {
-    assert
-      .that(() => mySuite.before())
-      .raises(new Error('The before() hook must include a function. Please provide a function or remove the before() and run again the tests.'));
-  });
+  // test('a before() hook with no function is considered invalid', () => {
+  //   assert
+  //     .that(() => mySuite.before())
+  //     .raises(new Error('The before() hook must include a function. Please provide a function or remove the before() and run again the tests.'));
+  // });
 
-  test('more than one after block is not allowed', () => {
-    mySuite.after(() => 3 + 4);
+  // test('more than one after block is not allowed', () => {
+  //   mySuite.after(() => 3 + 4);
 
-    assert
-      .that(() => mySuite.after(() => 5 + 6))
-      .raises(new Error('There is already a after() block. Please leave just one after() block and run again the tests.'));
-  });
+  //   assert
+  //     .that(() => mySuite.after(() => 5 + 6))
+  //     .raises(new Error('There is already a after() block. Please leave just one after() block and run again the tests.'));
+  // });
 
-  test('a after() hook with no function is considered invalid', () => {
-    assert
-      .that(() => mySuite.after())
-      .raises(new Error('The after() hook must include a function. Please provide a function or remove the after() and run again the tests.'));
-  });
+  // test('a after() hook with no function is considered invalid', () => {
+  //   assert
+  //     .that(() => mySuite.after())
+  //     .raises(new Error('The after() hook must include a function. Please provide a function or remove the after() and run again the tests.'));
+  // });
 
-  test('before() and after() hooks are executed in the right order', async() => {
-    const hookExecutions = ['start'];
+  // test('before() and after() hooks are executed in the right order', async() => {
+  //   const hookExecutions = ['start'];
 
-    mySuite.before(() => {
-      hookExecutions.push('before');
-    });
-    mySuite.after(() => {
-      hookExecutions.push('after');
-    });
-    mySuite.addTest(passingTest);
-    await runner.run();
+  //   mySuite.before(() => {
+  //     hookExecutions.push('before');
+  //   });
+  //   mySuite.after(() => {
+  //     hookExecutions.push('after');
+  //   });
+  //   mySuite.addTest(passingTest);
+  //   await runner.run();
 
-    assert.that(hookExecutions).includesExactly('start', 'before', 'after');
-  });
+  //   assert.that(hookExecutions).includesExactly('start', 'before', 'after');
+  // });
 
-  test('before() and after() on their asynchronous versions are executed in the right order', async() => {
-    const hookExecutions = ['start'];
+  // test('before() and after() on their asynchronous versions are executed in the right order', async() => {
+  //   const hookExecutions = ['start'];
 
-    mySuite.before(async() => {
-      Promise.resolve('before').then(value => hookExecutions.push(value));
-    });
-    mySuite.after(async() => {
-      Promise.resolve('after').then(value => hookExecutions.push(value));
-    });
-    mySuite.addTest(passingTest);
-    await runner.run();
+  //   mySuite.before(async() => {
+  //     Promise.resolve('before').then(value => hookExecutions.push(value));
+  //   });
+  //   mySuite.after(async() => {
+  //     Promise.resolve('after').then(value => hookExecutions.push(value));
+  //   });
+  //   mySuite.addTest(passingTest);
+  //   await runner.run();
 
-    assert.that(hookExecutions).includesExactly('start', 'before', 'after');
-  });
+  //   assert.that(hookExecutions).includesExactly('start', 'before', 'after');
+  // });
 
-  test('before() and after() hooks are executed once per test, no matter the result of each test', async() => {
-    const hookExecutions = ['start'];
+  // test('before() and after() hooks are executed once per test, no matter the result of each test', async() => {
+  //   const hookExecutions = ['start'];
 
-    mySuite.before(() => {
-      hookExecutions.push('before');
-    });
-    mySuite.after(() => {
-      hookExecutions.push('after');
-    });
-    mySuite.addTest(passingTest);
-    mySuite.addTest(failingTest);
-    mySuite.addTest(erroredTest);
-    await runner.run();
+  //   mySuite.before(() => {
+  //     hookExecutions.push('before');
+  //   });
+  //   mySuite.after(() => {
+  //     hookExecutions.push('after');
+  //   });
+  //   mySuite.addTest(passingTest);
+  //   mySuite.addTest(failingTest);
+  //   mySuite.addTest(erroredTest);
+  //   await runner.run();
 
-    assert.that(hookExecutions).includesExactly('start', 'before', 'after', 'before', 'after', 'before', 'after');
-  });
+  //   assert.that(hookExecutions).includesExactly('start', 'before', 'after', 'before', 'after', 'before', 'after');
+  // });
 
-  test('reporting failures and errors', async() => {
-    mySuite.addTest(passingTest);
-    mySuite.addTest(failingTest);
-    mySuite.addTest(erroredTest);
-    await runner.run();
+  // test('reporting failures and errors', async() => {
+  //   mySuite.addTest(passingTest);
+  //   mySuite.addTest(failingTest);
+  //   mySuite.addTest(erroredTest);
+  //   await runner.run();
 
-    assert.that(mySuite.allFailuresAndErrors()).includesExactly(failingTest, erroredTest);
-  });
+  //   assert.that(mySuite.allFailuresAndErrors()).includesExactly(failingTest, erroredTest);
+  // });
 
-  test('an empty suite can be executed and it reports zero tests', async() => {
-    await runner.run();
+  // test('an empty suite can be executed and it reports zero tests', async() => {
+  //   await runner.run();
 
-    assert.that(mySuite.totalCount()).isEqualTo(0);
-  });
+  //   assert.that(mySuite.totalCount()).isEqualTo(0);
+  // });
 
-  test('a suite including a test without body reports it as pending', async() => {
-    mySuite.addTest(pendingTest);
-    await runner.run();
+  // test('a suite including a test without body reports it as pending', async() => {
+  //   mySuite.addTest(pendingTest);
+  //   await runner.run();
 
-    assert.that(mySuite.totalCount()).isEqualTo(1);
-    assert.that(mySuite.pendingCount()).isEqualTo(1);
-    assert.that(mySuite.successCount()).isEqualTo(0);
-    assert.that(mySuite.failuresCount()).isEqualTo(0);
-    assert.that(mySuite.errorsCount()).isEqualTo(0);
-    assert.that(mySuite.skippedCount()).isEqualTo(0);
-  });
+  //   assert.that(mySuite.totalCount()).isEqualTo(1);
+  //   assert.that(mySuite.pendingCount()).isEqualTo(1);
+  //   assert.that(mySuite.successCount()).isEqualTo(0);
+  //   assert.that(mySuite.failuresCount()).isEqualTo(0);
+  //   assert.that(mySuite.errorsCount()).isEqualTo(0);
+  //   assert.that(mySuite.skippedCount()).isEqualTo(0);
+  // });
 
-  test('a suite cannot be created without a name', () => {
-    assert
-      .that(() => new TestSuite())
-      .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
-  });
+  // test('a suite cannot be created without a name', () => {
+  //   assert
+  //     .that(() => new TestSuite())
+  //     .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
+  // });
 
-  test('a suite cannot be created with an empty name', () => {
-    assert
-      .that(() => new TestSuite('  '))
-      .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
-  });
+  // test('a suite cannot be created with an empty name', () => {
+  //   assert
+  //     .that(() => new TestSuite('  '))
+  //     .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
+  // });
 
-  test('a suite cannot be created with a name that is not a string', () => {
-    assert
-      .that(() => new TestSuite(new Date()))
-      .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
-  });
+  // test('a suite cannot be created with a name that is not a string', () => {
+  //   assert
+  //     .that(() => new TestSuite(new Date()))
+  //     .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
+  // });
 
-  test('a suite cannot be created without a body', () => {
-    assert
-      .that(() => new TestSuite('hey'))
-      .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
-  });
+  // test('a suite cannot be created without a body', () => {
+  //   assert
+  //     .that(() => new TestSuite('hey'))
+  //     .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
+  // });
 
-  test('a suite cannot be created with a body that is not a function', () => {
-    assert
-      .that(() => new TestSuite('hey', 'ho'))
-      .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
-  });
+  // test('a suite cannot be created with a body that is not a function', () => {
+  //   assert
+  //     .that(() => new TestSuite('hey', 'ho'))
+  //     .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
+  // });
 
-  test('running with fail fast enabled stops at the first failure', async() => {
-    mySuite.addTest(passingTest);
-    mySuite.addTest(failingTest);
-    mySuite.addTest(erroredTest);
-    mySuite.addTest(pendingTest);
-    runner.setFailFastMode(FailFast.enabled());
+  // test('running with fail fast enabled stops at the first failure', async() => {
+  //   mySuite.addTest(passingTest);
+  //   mySuite.addTest(failingTest);
+  //   mySuite.addTest(erroredTest);
+  //   mySuite.addTest(pendingTest);
+  //   runner.setFailFastMode(FailFast.enabled());
 
-    await runner.run();
+  //   await runner.run();
 
-    assert.isTrue(passingTest.isSuccess());
-    assert.isTrue(failingTest.isFailure());
-    assert.isTrue(erroredTest.isSkipped());
-    assert.isTrue(pendingTest.isSkipped());
+  //   assert.isTrue(passingTest.isSuccess());
+  //   assert.isTrue(failingTest.isFailure());
+  //   assert.isTrue(erroredTest.isSkipped());
+  //   assert.isTrue(pendingTest.isSkipped());
 
-    assert.areEqual(mySuite.skippedCount(), 2);
-  });
+  //   assert.areEqual(mySuite.skippedCount(), 2);
+  // });
 
-  test('tests can be randomized based on a setting', async() => {
-    mySuite.addTest(passingTest);
-    mySuite.addTest(failingTest);
-    mySuite.addTest(erroredTest);
-    mySuite.addTest(pendingTest);
-    runner.setTestRandomness(true);
+  // test('tests can be randomized based on a setting', async() => {
+  //   mySuite.addTest(passingTest);
+  //   mySuite.addTest(failingTest);
+  //   mySuite.addTest(erroredTest);
+  //   mySuite.addTest(pendingTest);
+  //   runner.setTestRandomness(true);
 
-    const testsBefore = mySuite.tests();
-    await runner.run();
-    const testsAfter = mySuite.tests();
+  //   const testsBefore = mySuite.tests();
+  //   await runner.run();
+  //   const testsAfter = mySuite.tests();
 
-    // we cannot test how the random process was done, but at least we ensure we keep the same tests
-    assert.areEqual(new Set(testsBefore), new Set(testsAfter));
-  });
+  //   // we cannot test how the random process was done, but at least we ensure we keep the same tests
+  //   assert.areEqual(new Set(testsBefore), new Set(testsAfter));
+  // });
 
-  test('a skipped suite skips the execution of all its tests', () => {
+  test('a skipped suite skips the execution of all its tests', async () => {
     mySuite.addTest(passingTest);
     mySuite.addTest(failingTest);
     mySuite.addTest(erroredTest);
     mySuite.addTest(pendingTest);
 
     mySuite.skip();
+
+    await runner.run();
 
     assert.areEqual(mySuite.skippedCount(), 4);
     assert.isTrue(passingTest.isExplicitlySkipped());
@@ -207,20 +209,29 @@ suite('test suite behavior', () => {
     assert.isTrue(pendingTest.isExplicitlySkipped());
   });
 
-  test('a skipped suite skips the execution of before hooks', () => {
+  test('a skipped suite skips the execution of before hooks', async () => {
     let count = 0;
-    mySuite.before(() => count += 1);
+    mySuite.before(() => {
+      console.log('AAAAAAAA')
+      count += 1
+    });
 
-    mySuite.skip();
+    // mySuite.skip();
+    await runner.run();
 
     assert.that(count).isEqualTo(0);
   });
 
-  test('a skipped suite skips the execution of after hooks', () => {
+  test('a skipped suite skips the execution of after hooks', async () => {
     let count = 0;
-    mySuite.after(() => count += 1);
+    mySuite.after(() => {
+          console.log('AAAAAAAA')
+          count += 1
+        });
 
-    mySuite.skip();
+    // mySuite.skip();
+
+    await runner.run();
 
     assert.that(count).isEqualTo(0);
   });

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -22,177 +22,177 @@ suite('test suite behavior', () => {
     });
   });
 
-  // test('it is possible to retrieve the suite name', () => {
-  //   const testSuite = new TestSuite('my cool behavior', () => {});
+  test('it is possible to retrieve the suite name', () => {
+    const testSuite = new TestSuite('my cool behavior', () => {});
 
-  //   assert.that(testSuite.name()).isEqualTo('my cool behavior');
-  // });
+    assert.that(testSuite.name()).isEqualTo('my cool behavior');
+  });
 
-  // test('more than one before block is not allowed', () => {
-  //   mySuite.before(() => 3 + 4);
+  test('more than one before block is not allowed', () => {
+    mySuite.before(() => 3 + 4);
 
-  //   assert
-  //     .that(() => mySuite.before(() => 5 + 6))
-  //     .raises(new Error('There is already a before() block. Please leave just one before() block and run again the tests.'));
-  // });
+    assert
+      .that(() => mySuite.before(() => 5 + 6))
+      .raises(new Error('There is already a before() block. Please leave just one before() block and run again the tests.'));
+  });
 
-  // test('a before() hook with no function is considered invalid', () => {
-  //   assert
-  //     .that(() => mySuite.before())
-  //     .raises(new Error('The before() hook must include a function. Please provide a function or remove the before() and run again the tests.'));
-  // });
+  test('a before() hook with no function is considered invalid', () => {
+    assert
+      .that(() => mySuite.before())
+      .raises(new Error('The before() hook must include a function. Please provide a function or remove the before() and run again the tests.'));
+  });
 
-  // test('more than one after block is not allowed', () => {
-  //   mySuite.after(() => 3 + 4);
+  test('more than one after block is not allowed', () => {
+    mySuite.after(() => 3 + 4);
 
-  //   assert
-  //     .that(() => mySuite.after(() => 5 + 6))
-  //     .raises(new Error('There is already a after() block. Please leave just one after() block and run again the tests.'));
-  // });
+    assert
+      .that(() => mySuite.after(() => 5 + 6))
+      .raises(new Error('There is already a after() block. Please leave just one after() block and run again the tests.'));
+  });
 
-  // test('a after() hook with no function is considered invalid', () => {
-  //   assert
-  //     .that(() => mySuite.after())
-  //     .raises(new Error('The after() hook must include a function. Please provide a function or remove the after() and run again the tests.'));
-  // });
+  test('a after() hook with no function is considered invalid', () => {
+    assert
+      .that(() => mySuite.after())
+      .raises(new Error('The after() hook must include a function. Please provide a function or remove the after() and run again the tests.'));
+  });
 
-  // test('before() and after() hooks are executed in the right order', async() => {
-  //   const hookExecutions = ['start'];
+  test('before() and after() hooks are executed in the right order', async() => {
+    const hookExecutions = ['start'];
 
-  //   mySuite.before(() => {
-  //     hookExecutions.push('before');
-  //   });
-  //   mySuite.after(() => {
-  //     hookExecutions.push('after');
-  //   });
-  //   mySuite.addTest(passingTest);
-  //   await runner.run();
+    mySuite.before(() => {
+      hookExecutions.push('before');
+    });
+    mySuite.after(() => {
+      hookExecutions.push('after');
+    });
+    mySuite.addTest(passingTest);
+    await runner.run();
 
-  //   assert.that(hookExecutions).includesExactly('start', 'before', 'after');
-  // });
+    assert.that(hookExecutions).includesExactly('start', 'before', 'after');
+  });
 
-  // test('before() and after() on their asynchronous versions are executed in the right order', async() => {
-  //   const hookExecutions = ['start'];
+  test('before() and after() on their asynchronous versions are executed in the right order', async() => {
+    const hookExecutions = ['start'];
 
-  //   mySuite.before(async() => {
-  //     Promise.resolve('before').then(value => hookExecutions.push(value));
-  //   });
-  //   mySuite.after(async() => {
-  //     Promise.resolve('after').then(value => hookExecutions.push(value));
-  //   });
-  //   mySuite.addTest(passingTest);
-  //   await runner.run();
+    mySuite.before(async() => {
+      Promise.resolve('before').then(value => hookExecutions.push(value));
+    });
+    mySuite.after(async() => {
+      Promise.resolve('after').then(value => hookExecutions.push(value));
+    });
+    mySuite.addTest(passingTest);
+    await runner.run();
 
-  //   assert.that(hookExecutions).includesExactly('start', 'before', 'after');
-  // });
+    assert.that(hookExecutions).includesExactly('start', 'before', 'after');
+  });
 
-  // test('before() and after() hooks are executed once per test, no matter the result of each test', async() => {
-  //   const hookExecutions = ['start'];
+  test('before() and after() hooks are executed once per test, no matter the result of each test', async() => {
+    const hookExecutions = ['start'];
 
-  //   mySuite.before(() => {
-  //     hookExecutions.push('before');
-  //   });
-  //   mySuite.after(() => {
-  //     hookExecutions.push('after');
-  //   });
-  //   mySuite.addTest(passingTest);
-  //   mySuite.addTest(failingTest);
-  //   mySuite.addTest(erroredTest);
-  //   await runner.run();
+    mySuite.before(() => {
+      hookExecutions.push('before');
+    });
+    mySuite.after(() => {
+      hookExecutions.push('after');
+    });
+    mySuite.addTest(passingTest);
+    mySuite.addTest(failingTest);
+    mySuite.addTest(erroredTest);
+    await runner.run();
 
-  //   assert.that(hookExecutions).includesExactly('start', 'before', 'after', 'before', 'after', 'before', 'after');
-  // });
+    assert.that(hookExecutions).includesExactly('start', 'before', 'after', 'before', 'after', 'before', 'after');
+  });
 
-  // test('reporting failures and errors', async() => {
-  //   mySuite.addTest(passingTest);
-  //   mySuite.addTest(failingTest);
-  //   mySuite.addTest(erroredTest);
-  //   await runner.run();
+  test('reporting failures and errors', async() => {
+    mySuite.addTest(passingTest);
+    mySuite.addTest(failingTest);
+    mySuite.addTest(erroredTest);
+    await runner.run();
 
-  //   assert.that(mySuite.allFailuresAndErrors()).includesExactly(failingTest, erroredTest);
-  // });
+    assert.that(mySuite.allFailuresAndErrors()).includesExactly(failingTest, erroredTest);
+  });
 
-  // test('an empty suite can be executed and it reports zero tests', async() => {
-  //   await runner.run();
+  test('an empty suite can be executed and it reports zero tests', async() => {
+    await runner.run();
 
-  //   assert.that(mySuite.totalCount()).isEqualTo(0);
-  // });
+    assert.that(mySuite.totalCount()).isEqualTo(0);
+  });
 
-  // test('a suite including a test without body reports it as pending', async() => {
-  //   mySuite.addTest(pendingTest);
-  //   await runner.run();
+  test('a suite including a test without body reports it as pending', async() => {
+    mySuite.addTest(pendingTest);
+    await runner.run();
 
-  //   assert.that(mySuite.totalCount()).isEqualTo(1);
-  //   assert.that(mySuite.pendingCount()).isEqualTo(1);
-  //   assert.that(mySuite.successCount()).isEqualTo(0);
-  //   assert.that(mySuite.failuresCount()).isEqualTo(0);
-  //   assert.that(mySuite.errorsCount()).isEqualTo(0);
-  //   assert.that(mySuite.skippedCount()).isEqualTo(0);
-  // });
+    assert.that(mySuite.totalCount()).isEqualTo(1);
+    assert.that(mySuite.pendingCount()).isEqualTo(1);
+    assert.that(mySuite.successCount()).isEqualTo(0);
+    assert.that(mySuite.failuresCount()).isEqualTo(0);
+    assert.that(mySuite.errorsCount()).isEqualTo(0);
+    assert.that(mySuite.skippedCount()).isEqualTo(0);
+  });
 
-  // test('a suite cannot be created without a name', () => {
-  //   assert
-  //     .that(() => new TestSuite())
-  //     .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
-  // });
+  test('a suite cannot be created without a name', () => {
+    assert
+      .that(() => new TestSuite())
+      .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
+  });
 
-  // test('a suite cannot be created with an empty name', () => {
-  //   assert
-  //     .that(() => new TestSuite('  '))
-  //     .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
-  // });
+  test('a suite cannot be created with an empty name', () => {
+    assert
+      .that(() => new TestSuite('  '))
+      .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
+  });
 
-  // test('a suite cannot be created with a name that is not a string', () => {
-  //   assert
-  //     .that(() => new TestSuite(new Date()))
-  //     .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
-  // });
+  test('a suite cannot be created with a name that is not a string', () => {
+    assert
+      .that(() => new TestSuite(new Date()))
+      .raises(new Error('Suite does not have a valid name. Please enter a non-empty string to name this suite.'));
+  });
 
-  // test('a suite cannot be created without a body', () => {
-  //   assert
-  //     .that(() => new TestSuite('hey'))
-  //     .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
-  // });
+  test('a suite cannot be created without a body', () => {
+    assert
+      .that(() => new TestSuite('hey'))
+      .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
+  });
 
-  // test('a suite cannot be created with a body that is not a function', () => {
-  //   assert
-  //     .that(() => new TestSuite('hey', 'ho'))
-  //     .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
-  // });
+  test('a suite cannot be created with a body that is not a function', () => {
+    assert
+      .that(() => new TestSuite('hey', 'ho'))
+      .raises(new Error('Suite does not have a valid body. Please provide a function to declare the suite body.'));
+  });
 
-  // test('running with fail fast enabled stops at the first failure', async() => {
-  //   mySuite.addTest(passingTest);
-  //   mySuite.addTest(failingTest);
-  //   mySuite.addTest(erroredTest);
-  //   mySuite.addTest(pendingTest);
-  //   runner.setFailFastMode(FailFast.enabled());
+  test('running with fail fast enabled stops at the first failure', async() => {
+    mySuite.addTest(passingTest);
+    mySuite.addTest(failingTest);
+    mySuite.addTest(erroredTest);
+    mySuite.addTest(pendingTest);
+    runner.setFailFastMode(FailFast.enabled());
 
-  //   await runner.run();
+    await runner.run();
 
-  //   assert.isTrue(passingTest.isSuccess());
-  //   assert.isTrue(failingTest.isFailure());
-  //   assert.isTrue(erroredTest.isSkipped());
-  //   assert.isTrue(pendingTest.isSkipped());
+    assert.isTrue(passingTest.isSuccess());
+    assert.isTrue(failingTest.isFailure());
+    assert.isTrue(erroredTest.isSkipped());
+    assert.isTrue(pendingTest.isSkipped());
 
-  //   assert.areEqual(mySuite.skippedCount(), 2);
-  // });
+    assert.areEqual(mySuite.skippedCount(), 2);
+  });
 
-  // test('tests can be randomized based on a setting', async() => {
-  //   mySuite.addTest(passingTest);
-  //   mySuite.addTest(failingTest);
-  //   mySuite.addTest(erroredTest);
-  //   mySuite.addTest(pendingTest);
-  //   runner.setTestRandomness(true);
+  test('tests can be randomized based on a setting', async() => {
+    mySuite.addTest(passingTest);
+    mySuite.addTest(failingTest);
+    mySuite.addTest(erroredTest);
+    mySuite.addTest(pendingTest);
+    runner.setTestRandomness(true);
 
-  //   const testsBefore = mySuite.tests();
-  //   await runner.run();
-  //   const testsAfter = mySuite.tests();
+    const testsBefore = mySuite.tests();
+    await runner.run();
+    const testsAfter = mySuite.tests();
 
-  //   // we cannot test how the random process was done, but at least we ensure we keep the same tests
-  //   assert.areEqual(new Set(testsBefore), new Set(testsAfter));
-  // });
+    // we cannot test how the random process was done, but at least we ensure we keep the same tests
+    assert.areEqual(new Set(testsBefore), new Set(testsAfter));
+  });
 
-  test('a skipped suite skips the execution of all its tests', async () => {
+  test('a skipped suite skips the execution of all its tests', async() => {
     mySuite.addTest(passingTest);
     mySuite.addTest(failingTest);
     mySuite.addTest(erroredTest);
@@ -209,27 +209,28 @@ suite('test suite behavior', () => {
     assert.isTrue(pendingTest.isExplicitlySkipped());
   });
 
-  test('a skipped suite skips the execution of before hooks', async () => {
+  test('a skipped suite skips the execution of before hooks', async() => {
     let count = 0;
     mySuite.before(() => {
-      console.log('AAAAAAAA')
-      count += 1
+      count += 1;
     });
 
-    // mySuite.skip();
+    mySuite.addTest(passingTest);
+    mySuite.skip();
     await runner.run();
 
     assert.that(count).isEqualTo(0);
   });
 
-  test('a skipped suite skips the execution of after hooks', async () => {
+  test('a skipped suite skips the execution of after hooks', async() => {
     let count = 0;
-    mySuite.after(() => {
-          console.log('AAAAAAAA')
-          count += 1
-        });
 
-    // mySuite.skip();
+    mySuite.after(() => {
+      count += 1;
+    });
+
+    mySuite.addTest(passingTest);
+    mySuite.skip();
 
     await runner.run();
 

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -191,4 +191,37 @@ suite('test suite behavior', () => {
     // we cannot test how the random process was done, but at least we ensure we keep the same tests
     assert.areEqual(new Set(testsBefore), new Set(testsAfter));
   });
+
+  test('a skipped suite skips the execution of all its tests', () => {
+    mySuite.addTest(passingTest);
+    mySuite.addTest(failingTest);
+    mySuite.addTest(erroredTest);
+    mySuite.addTest(pendingTest);
+
+    mySuite.skip()
+
+    assert.areEqual(mySuite.skippedCount(), 4);
+    assert.isTrue(passingTest.isExplicitlySkipped());
+    assert.isTrue(failingTest.isExplicitlySkipped());
+    assert.isTrue(erroredTest.isExplicitlySkipped());
+    assert.isTrue(pendingTest.isExplicitlySkipped());
+  });
+
+  test('a skipped suite skips the execution of before hooks', () => {
+    let count = 0;
+    mySuite.before(() => count = count + 1);
+
+    mySuite.skip()
+
+    assert.that(count).isEqualTo(0);
+  });
+
+  test('a skipped suite skips the execution of after hooks', () => {
+    let count = 0;
+    mySuite.after(() => count = count + 1);
+
+    mySuite.skip()
+
+    assert.that(count).isEqualTo(0);
+  })
 });

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -202,7 +202,13 @@ suite('test suite behavior', () => {
 
     await runner.run();
 
-    assert.areEqual(mySuite.skippedCount(), 4);
+    assert.that(mySuite.totalCount()).isEqualTo(4);
+    assert.that(mySuite.pendingCount()).isEqualTo(0);
+    assert.that(mySuite.successCount()).isEqualTo(0);
+    assert.that(mySuite.failuresCount()).isEqualTo(0);
+    assert.that(mySuite.errorsCount()).isEqualTo(0);
+    assert.that(mySuite.skippedCount()).isEqualTo(4);
+    
     assert.isTrue(passingTest.isExplicitlySkipped());
     assert.isTrue(failingTest.isExplicitlySkipped());
     assert.isTrue(erroredTest.isExplicitlySkipped());

--- a/tests/core/test_suite_test.js
+++ b/tests/core/test_suite_test.js
@@ -198,7 +198,7 @@ suite('test suite behavior', () => {
     mySuite.addTest(erroredTest);
     mySuite.addTest(pendingTest);
 
-    mySuite.skip()
+    mySuite.skip();
 
     assert.areEqual(mySuite.skippedCount(), 4);
     assert.isTrue(passingTest.isExplicitlySkipped());
@@ -209,19 +209,19 @@ suite('test suite behavior', () => {
 
   test('a skipped suite skips the execution of before hooks', () => {
     let count = 0;
-    mySuite.before(() => count = count + 1);
+    mySuite.before(() => count += 1);
 
-    mySuite.skip()
+    mySuite.skip();
 
     assert.that(count).isEqualTo(0);
   });
 
   test('a skipped suite skips the execution of after hooks', () => {
     let count = 0;
-    mySuite.after(() => count = count + 1);
+    mySuite.after(() => count += 1);
 
-    mySuite.skip()
+    mySuite.skip();
 
     assert.that(count).isEqualTo(0);
-  })
+  });
 });

--- a/tests/ui/formatter_test.js
+++ b/tests/ui/formatter_test.js
@@ -34,12 +34,12 @@ suite('formatter', () => {
     });
   });
 
-  test('display skipped status in grey when explicitly skipping a test', async() => {
+  test('display skipped status in cyan when explicitly skipping a test', async() => {
     await withRunner(async(runner, _assert, _fail) => {
       const skippedTest = anExplicitlySkippedTest();
       await resultOfASuiteWith(runner, skippedTest);
       formatter.displaySkippedResult(skippedTest);
-      const testResultMessage = '[\x1B[30m\x1B[1mSKIP\x1B[0m] \x1B[30ma test that is skipped\x1B[0m';
+      const testResultMessage = '[\x1B[36m\x1B[1mSKIP\x1B[0m] \x1B[36ma test that is skipped\x1B[0m';
       assert.that(fakeConsole.messages()).includesExactly(testResultMessage);
     });
   });


### PR DESCRIPTION
## What

Adding the feature to skip a suite by doing .skip(). This will block the suite body from being run and will display all the tests from the suite as [SKIP] in the result. `before` and `after` blocks won't be executed for a skipped suite. 

## Link to issue(s)

Issue(s) this PR fixes. Example:

* [[feature] skip a suite](https://github.com/ngarbezza/testy/issues/305)

## Contribution guidelines

- [ ] I have read the [Contributing guidelines](/CONTRIBUTING.md)
