### PR TITLE
Increasing max amount of allowed parameters per constructor from 3 to 4

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -266,7 +266,7 @@ export default [
       'max-lines': 'error',
       'max-lines-per-function': 'error',
       'max-nested-callbacks': 'error',
-      'max-params': 'error',
+      'max-params': ['error', { max: 4 }],
       'max-statements': 'error',
     },
   },


### PR DESCRIPTION
## What
We've made some changes in [this PR](https://github.com/ngarbezza/testy/pull/317) that require a constructor to be able to receive 4 parameters. By default ESLint allows 3 so we are increasing it 

## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)
