### PR TITLE
Increasing max amount of statements from 10 to 11

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -267,7 +267,7 @@ export default [
       'max-lines-per-function': 'error',
       'max-nested-callbacks': 'error',
       'max-params': ['error', { max: 4 }],
-      'max-statements': 'error',
+      'max-statements': ['error', { max: 11 }],
     },
   },
   {


### PR DESCRIPTION
## What

We've made some changes in https://github.com/ngarbezza/testy/pull/320 that require a the max amount of statements to be 11. By default ESLint allows 10 so we are increasing it

## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)
