### PR TITLE
🐛 fix: Wrong amount of arguments for invalid usage of numerical assertions

### DIFF
--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -586,7 +586,7 @@ export class Assertion extends TestResultReporter {
       throw new InvalidAssertionError(I18nMessage.of('invalid_actual_object_in_numerical_comparison', this.#actualResultAsString(), typeof this.#actual));
     }
     if (!isNumber(number)) {
-      throw new InvalidAssertionError(I18nMessage.of('invalid_object_in_numerical_comparison', this.#actualResultAsString(), typeof number));
+      throw new InvalidAssertionError(I18nMessage.of('invalid_object_in_numerical_comparison', number, typeof number));
     }
   }
 }

--- a/lib/i18n/translations.json
+++ b/lib/i18n/translations.json
@@ -59,8 +59,8 @@
     "error_running_suites": "Error executing the test suites",
     "reached_timeout_error": "Timeout of 50ms reached. Your test could not finish its execution.",
     "invalid_actual_object_in_exception_assertion": "Actual value for this assertion must be a function, got %s",
-    "invalid_actual_object_in_numerical_comparison": "Actual value for this assertion must be a number, got %s",
-    "invalid_object_in_numerical_comparison": "Value for this assertion must be a number, got %s",
+    "invalid_actual_object_in_numerical_comparison": "Actual value for this assertion must be a number, %s argument has type %s",
+    "invalid_object_in_numerical_comparison": "Value for this assertion must be a number, %s argument has type %s",
     "file": "file"
   },
   "es": {
@@ -123,8 +123,8 @@
     "error_running_suites": "Error ejecutando las suites de test",
     "reached_timeout_error": "Se alcanzó el tiempo límite de %sms. El test no se terminó de ejecutar.",
     "invalid_actual_object_in_exception_assertion": "Es necesario proveer una función para este tipo de aserción, se obtuvo %s",
-    "invalid_actual_object_in_numerical_comparison": "Es necesario proveer un número para este tipo de aserción, se obtuvo %s",
-    "invalid_object_in_numerical_comparison": "Es necesario proveer un número como argumento para este tipo de aserción, se obtuvo %s",
+    "invalid_actual_object_in_numerical_comparison": "Es necesario proveer un número para este tipo de aserción, el argumento %s tiene tipo %s",
+    "invalid_object_in_numerical_comparison": "Es necesario proveer un número como argumento para este tipo de aserción, el argumento %s tiene tipo %s",
     "file": "archivo"
   },
   "it": {
@@ -187,8 +187,8 @@
     "error_running_suites": "Errore durante l'esecuzione delle suite di test",
     "reached_timeout_error": "Timeout %sms raggiunto. Il test non è terminato.",
     "invalid_actual_object_in_exception_assertion": "È necessario fornire una funzione per questo tipo di asserzione. É stato ottenuto %s",
-    "invalid_actual_object_in_numerical_comparison": "È necessario fornire un numero per questo tipo di asserzione. É stato ottenuto %s",
-    "invalid_object_in_numerical_comparison": "È necessario fornire un numero come argomento per questo tipo di affermazione. É stato ottenuto %s",
+    "invalid_actual_object_in_numerical_comparison": "È necessario fornire un numero per questo tipo di asserzione. L'argomento %s ha un tipo %s",
+    "invalid_object_in_numerical_comparison": "È necessario fornire un numero come argomento per questo tipo di affermazione. L'argomento %s ha un tipo %s",
     "file": "archivio"
   }
 }

--- a/tests/core/assertions/numeric_assertions_test.js
+++ b/tests/core/assertions/numeric_assertions_test.js
@@ -69,7 +69,7 @@ suite('numeric assertions', () => {
   test('isGreaterThan fails when comparing something that is not a number', async() => {
     const result = await resultOfATestWith(assert => assert.that(2).isGreaterThan(false));
 
-    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', '2', 'boolean'), '');
+    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', false, 'boolean'), '');
   });
 
   test('isLessThan passes if the number is strictly bigger', async() => {
@@ -99,7 +99,7 @@ suite('numeric assertions', () => {
   test('isLessThan fails when comparing something that is not a number', async() => {
     const result = await resultOfATestWith(assert => assert.that(2).isLessThan(false));
 
-    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', '2', 'boolean'), '');
+    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', false, 'boolean'), '');
   });
 
   test('isGreaterThanOrEqualTo passes if the number is strictly smaller', async() => {
@@ -129,7 +129,7 @@ suite('numeric assertions', () => {
   test('isGreaterThanOrEqualTo fails when comparing something that is not a number', async() => {
     const result = await resultOfATestWith(assert => assert.that(2).isGreaterThanOrEqualTo(false));
 
-    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', '2', 'boolean'), '');
+    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', false, 'boolean'), '');
   });
 
   test('isLessThanOrEqualTo passes if the number is strictly bigger', async() => {
@@ -159,6 +159,6 @@ suite('numeric assertions', () => {
   test('isLessThanOrEqualTo fails when comparing something that is not a number', async() => {
     const result = await resultOfATestWith(assert => assert.that(2).isLessThanOrEqualTo(false));
 
-    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', '2', 'boolean'), '');
+    expectErrorOn(result, I18nMessage.of('invalid_object_in_numerical_comparison', false, 'boolean'), '');
   });
 });


### PR DESCRIPTION
## What

There was a bug when using numerical assertions `isGreaterThan`, `isLessThan`, `isGreaterThanOrEqualTo` and `isLessThanOrEqualTo`. The translation was expecting 1 argument only but 2 were being sent when throwing the exception InvalidAssertionError. This exception is thrown when 1 of the arguments used for these assertions is not a number. 
I added a second parameter to the translations so it's easier to understand which of the 2 values is the one that has an invalid type. 
Also for the scenario where the sent number (not the #actual value) was not a number, the #actual number was being sent as argument to the translation instead of the other number. 

For the test
```
test('I am a test', async () => {
    assert.that(true).isGreaterThan(3)
  })
```

Before: 
<img width="508" alt="image" src="https://github.com/user-attachments/assets/9e94c6a3-5542-4e86-8d02-78f1e12335f1" />

Now: 

<img width="614" alt="image" src="https://github.com/user-attachments/assets/9fa9821c-6b84-4017-9a95-1de43d51f4bb" />



## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)
