### PR TITLE
🐛 fix: Console configuration parameters not informing errors in the proper way

### DIFF
--- a/lib/config/parameters_parser.js
+++ b/lib/config/parameters_parser.js
@@ -1,5 +1,9 @@
 import { I18n } from '../i18n/i18n.js';
 import { isString } from '../utils.js';
+import {
+  InvalidConfigurationParameterError,
+  InvalidConfigurationParametersOrderError,
+} from '../errors.js';
 
 /**
  * I transform a list of console parameters into a valid configuration object.
@@ -55,15 +59,25 @@ export class ParametersParser {
     params.splice(languageParamIndex, 2);
   }
 
+  static validateConfigurationParams(paramsList) {
+    paramsList.forEach((param, index) => {
+      if (this.isLanguageParam(param)) {
+        this.validateLanguageOption(paramsList, index);
+      }
+
+      if (!this.isRawConfigurationParam(param)) {
+        throw new InvalidConfigurationParametersOrderError('Run configuration parameters should always be sent at the end of test paths routes');
+      }
+    });
+  }
+
   static getPathsAndConfigurationParams(allParams) {
     const firstConfigParamIndex = allParams.findIndex(param => this.isRawConfigurationParam(param));
 
     if (firstConfigParamIndex >= 0) {
       const paramsAfterFirstConfigurationParam = allParams.slice(firstConfigParamIndex);
-      const thereIsPathParamAfterConfigParams = paramsAfterFirstConfigurationParam.some(param => !this.isRawConfigurationParam(param));
-      if (thereIsPathParamAfterConfigParams) {
-        throw new Error('Run configuration parameters should always be sent at the end of test paths routes');
-      }
+      this.validateConfigurationParams(paramsAfterFirstConfigurationParam);
+
       return {
         pathsParams: allParams.slice(0, firstConfigParamIndex),
         configurationParams: allParams.slice(firstConfigParamIndex),
@@ -76,14 +90,10 @@ export class ParametersParser {
     };
   }
 
-  static isConfigurationParam(param) {
-    return this.isFailFastParam(param) || this.isRandomizeParam(param) || this.isLanguageParam(param);
-  }
-
   static isRawConfigurationParam(param) {
     // pre sanitization
     const supportedLanguages = I18n.supportedLanguages();
-    return this.isConfigurationParam(param) || supportedLanguages.includes(param);
+    return supportedLanguages.includes(param) || param[0] === '-';
   }
 
   static isFailFastParam(string) {
@@ -141,6 +151,6 @@ class InvalidConfigurationParameter {
   }
 
   static handle(configurationParam) {
-    throw new Error(`Cannot parse invalid run configuration parameter ${configurationParam}. Please run --help option to check available options.`);
+    throw new InvalidConfigurationParameterError(`Cannot parse invalid run configuration parameter ${configurationParam}.`);
   }
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -13,3 +13,6 @@ class TestyError extends Error {
 
 export class InvalidAssertionError extends TestyError {}
 export class InvalidConfigurationError extends TestyError {}
+export class InvalidConfigurationParameterError extends TestyError {}
+export class InvalidConfigurationParametersOrderError extends TestyError {}
+export class UnsupportedLanguageError extends TestyError {}

--- a/lib/i18n/i18n.js
+++ b/lib/i18n/i18n.js
@@ -2,6 +2,7 @@ import { isUndefined } from '../utils.js';
 
 // Change to import assertions when reaching Node 18
 import { createRequire } from 'node:module';
+import { UnsupportedLanguageError } from '../errors.js';
 const require = createRequire(import.meta.url);
 const TRANSLATIONS = require('./translations');
 
@@ -38,7 +39,7 @@ class I18n {
   }
 
   static unsupportedLanguageException(languageCode, supportedLanguages) {
-    throw new Error(`Language '${languageCode}' is not supported. Allowed values: ${supportedLanguages.join(', ')}`);
+    throw new UnsupportedLanguageError(`Language '${languageCode}' is not supported. Allowed values: ${supportedLanguages.join(', ')}`);
   }
 
   constructor(languageCode, translations = TRANSLATIONS) {

--- a/lib/script_action.js
+++ b/lib/script_action.js
@@ -3,7 +3,12 @@ import console from 'node:console';
 
 import { Testy } from './testy.js';
 import { Configuration } from './config/configuration.js';
-import { InvalidConfigurationError } from './errors.js';
+import {
+  InvalidConfigurationError,
+  InvalidConfigurationParameterError,
+  InvalidConfigurationParametersOrderError,
+  UnsupportedLanguageError,
+} from './errors.js';
 
 // Change to import assertions when reaching Node 18
 import { createRequire } from 'module';
@@ -93,16 +98,27 @@ const RunTests = {
       await testyInstance.run(pathsParams);
       this._exitSuccessfully();
     } catch (error) {
-      if (error instanceof InvalidConfigurationError) {
-        this._handleInvalidConfigurationError(error);
-      } else {
-        this._handleUnexpectedError(error);
-      }
+      this._handleExecutionError(error);
       this._exitWithFailure();
     }
   },
 
   // Private
+
+  _isParsingParametersError(error) {
+    return error instanceof InvalidConfigurationParameterError || error instanceof InvalidConfigurationParametersOrderError || error instanceof UnsupportedLanguageError;
+  },
+
+  _handleExecutionError(error) {
+    if (error instanceof InvalidConfigurationError) {
+      this._handleInvalidConfigurationError(error);
+    }
+    if (this._isParsingParametersError(error)) {
+      this._handleParsingParametersError(error);
+    } else {
+      this._handleUnexpectedError(error);
+    }
+  },
 
   _handleInvalidConfigurationError(error) {
     console.log('Sorry, an error was found loading the configuration. Details below:');
@@ -115,5 +131,11 @@ const RunTests = {
     console.log('Sorry, an unexpected error happened while loading Testy, you did nothing wrong. Details below:');
     console.log(error.stack);
     console.log(`Please report this issue including the full error message and stacktrace at ${bugs.url}.`);
+  },
+
+  _handleParsingParametersError(error) {
+    console.log('Sorry, an error happened while parsing configuration parameters:');
+    console.log(`=> ${error.reason()}`);
+    console.log('Please run -h or --help options to check available parameters');
   },
 };

--- a/tests/configuration/parameters_parser_test.js
+++ b/tests/configuration/parameters_parser_test.js
@@ -1,6 +1,11 @@
 import { assert, suite, test } from '../../lib/testy.js';
 import { ParametersParser } from '../../lib/config/parameters_parser.js';
 import { I18n } from '../../lib/i18n/i18n.js';
+import {
+  InvalidConfigurationParameterError,
+  InvalidConfigurationParametersOrderError,
+  UnsupportedLanguageError,
+} from '../../lib/errors.js';
 
 suite('Parameters parser', () => {
 
@@ -52,7 +57,7 @@ suite('Parameters parser', () => {
   test('throws an error when sending unknown params', () => {
     assert
       .that(() => ParametersParser.generateRunConfigurationFromParams(['fake param']))
-      .raises(new Error(`Cannot parse invalid run configuration parameter ${'fake param'}. Please run --help option to check available options.`));
+      .raises(new InvalidConfigurationParameterError(`Cannot parse invalid run configuration parameter ${'fake param'}.`));
   });
 
   test('splits between path params and configuration params', () => {
@@ -89,7 +94,7 @@ suite('Parameters parser', () => {
     const testPath1 = 'I am a test path';
     assert
       .that(() => ParametersParser.getPathsAndConfigurationParams(['-f', testPath1]))
-      .raises(new Error('Run configuration parameters should always be sent at the end of test paths routes'));
+      .raises(new InvalidConfigurationParametersOrderError('Run configuration parameters should always be sent at the end of test paths routes'));
   });
 
   test('returns sanitized params when passing a valid list of params', () => {
@@ -105,12 +110,12 @@ suite('Parameters parser', () => {
   test('throws an error when sending invalid language option', () => {
     assert
       .that(() => ParametersParser.sanitizeParameters(['-l', 'fakeLanguage']))
-      .raises(new Error(`Language '${'fakeLanguage'}' is not supported. Allowed values: ${I18n.supportedLanguages().join(', ')}`));
+      .raises(new UnsupportedLanguageError(`Language '${'fakeLanguage'}' is not supported. Allowed values: ${I18n.supportedLanguages().join(', ')}`));
   });
 
   test('throws an error when language parameters do not have the proper order', () => {
     assert
       .that(() => ParametersParser.sanitizeParameters(['it', '-l']))
-      .raises(new Error(`Language '${undefined}' is not supported. Allowed values: ${I18n.supportedLanguages().join(', ')}`));
+      .raises(new UnsupportedLanguageError(`Language '${undefined}' is not supported. Allowed values: ${I18n.supportedLanguages().join(', ')}`));
   });
 });

--- a/tests/configuration/parameters_parser_test.js
+++ b/tests/configuration/parameters_parser_test.js
@@ -118,4 +118,23 @@ suite('Parameters parser', () => {
       .that(() => ParametersParser.sanitizeParameters(['it', '-l']))
       .raises(new UnsupportedLanguageError(`Language '${undefined}' is not supported. Allowed values: ${I18n.supportedLanguages().join(', ')}`));
   });
+
+  test('validateConfigurationParams fails if a path param is sent', () => {
+    const testPath1 = 'I am a test path';
+    assert
+      .that(() => ParametersParser.validateConfigurationParams(['-f', testPath1]))
+      .raises(new InvalidConfigurationParametersOrderError('Run configuration parameters should always be sent at the end of test paths routes'));
+  });
+
+  test('validateConfigurationParams fails if language option is not valid', () => {
+    assert
+      .that(() => ParametersParser.validateConfigurationParams(['-l', 'de']))
+      .raises(new UnsupportedLanguageError(`Language 'de' is not supported. Allowed values: ${I18n.supportedLanguages().join(', ')}`));
+  });
+
+  test('validateConfigurationParams passes if language option is valid', () => {
+    assert
+      .that(() => ParametersParser.validateConfigurationParams(['-l', 'it']))
+      .doesNotRaiseAnyErrors();
+  });
 });


### PR DESCRIPTION
Modifying how ParametersParser validates parameters and informing errors in a more clear way

## What

Even though the happy path for sending configuration parameters through the console was working okey, the way the errors were informed when the params were sent incorrectly was not giving a clear feedback. i.e:
If the user sent an unknown parameter, the error said that the route + the parameter did not exist 
<img width="938" alt="image" src="https://github.com/user-attachments/assets/a9b3eb26-86b7-4fd2-9d61-64426eb42200" />

When sending an unknown language, the error displayed considered the parameter a path parameter, printing this error:
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/ca9bd37d-711f-4b72-8326-c10aacae159c" />

----------------------------------------------------------------------------------------
NOW

When sending an unknown parameter
<img width="935" alt="image" src="https://github.com/user-attachments/assets/2c093bda-90ba-46bd-8b48-ef9c84eb5f56" />

When sending an unknown language option
<img width="956" alt="image" src="https://github.com/user-attachments/assets/de52a02e-2aea-42ab-b544-04a8a233e935" />

When sending a path param after a configuration param:

<img width="934" alt="image" src="https://github.com/user-attachments/assets/7367ef00-e61c-41bc-8549-faa55e3b066a" />

----------------------------------------------------------------------------------------
## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)
