### PR TITLE
[Feature ✨] Adding directory flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ test file path:
 - `-f` or `--fail-fast` to enable fail fast mode.
 - `-r` or `--randomize` to enable the execution of tests in random order.
 - `-l xx` or `--language xx` where `xx` must be either `es` for Spanish, `en` for English or `it` for Italian.
+- `-d route` or `--directory route` where `route` must be a directory that contains test files. If explicit test routes are provided, this directory parameter will be ignored.
 
 These console parameters can be sent in any order and combined as you want.
 

--- a/README_es.md
+++ b/README_es.md
@@ -124,6 +124,7 @@ que quieras ejecutar:
 - `-f` o `--fail-fast` para habilitar el modo _fail fast_.
 - `-r` o `--randomize` para habilitar la ejecución de tests en orden aleatorio.
 - `-l xx` o `--language xx` done `xx` debe ser `es` para español, `en` para inglés o `it` para italiano.
+- `-d ruta` or `--directory ruta` donde `ruta` debe ser un directorio que contiene archivos de test. Si se proveen rutas explicitas de tests para ejecutar, este parametro será ignorado.
 
 Estos parámetros por consola pueden ser enviados en el orden que desees y puedes combinarlos como quieras. Toman
 precedencia respecto a los que estén configurados en `.testyrc.json`.

--- a/lib/config/parameters_parser.js
+++ b/lib/config/parameters_parser.js
@@ -37,7 +37,7 @@ export class ParametersParser {
   }
 
   static sanitizeParameters(params) {
-    let sanitizedParams = params
+    let sanitizedParams = params;
 
     const languageParamIndex = params.findIndex(param => param === '-l' || param === '--language');
     if (languageParamIndex >= 0) {
@@ -73,9 +73,9 @@ export class ParametersParser {
   }
 
   static sanitizeDirectoryParamOptions(params, directoryParamIndex) {
-    const directoryOption = params[directoryParamIndex + 1]
-    if(directoryOption === undefined) {
-      throw new ConfigurationParsingError('Must send a route for --directory option')
+    const directoryOption = params[directoryParamIndex + 1];
+    if (directoryOption === undefined) {
+      throw new ConfigurationParsingError('Must send a route for --directory option');
     }
     const directoryConfig = [`-d ${directoryOption}`];
     this.removeParameterAtIndex(params, directoryParamIndex);
@@ -88,8 +88,8 @@ export class ParametersParser {
         this.validateLanguageOption(paramsList, index);
       }
 
-      const previousParam = paramsList[index - 1]
-      const previousParamIsDirectoryFlag = previousParam === '-d' || previousParam === '--directory'
+      const previousParam = paramsList[index - 1];
+      const previousParamIsDirectoryFlag = previousParam === '-d' || previousParam === '--directory';
 
       if (!this.isRawConfigurationParam(param) && !previousParamIsDirectoryFlag) {
         throw new ConfigurationParsingError('Run configuration parameters should always be sent at the end of test paths routes');

--- a/lib/config/parameters_parser.js
+++ b/lib/config/parameters_parser.js
@@ -28,6 +28,7 @@ export class ParametersParser {
       FailFastConfigurationParameterParser,
       RandomizeConfigurationParameterParser,
       LanguageConfigurationParameterParser,
+      DirectoryConfigurationParameterParser,
       InvalidConfigurationParameter,
     ].find(configurationParameterParser =>
       configurationParameterParser.canHandle(param),
@@ -37,8 +38,12 @@ export class ParametersParser {
 
   static sanitizeParameters(params) {
     const languageParamIndex = params.findIndex(param => param === '-l' || param === '--language');
+    const directoryParamIndex = params.findIndex(param => param === '-d' || param === '--directory');
     if (languageParamIndex >= 0) {
       return this.sanitizeLanguageParamOptions(params, languageParamIndex);
+    }
+    if (directoryParamIndex >= 0) {
+      return this.sanitizeDirectoryParamOptions(params, directoryParamIndex);
     }
     return params;
   }
@@ -46,7 +51,7 @@ export class ParametersParser {
   static sanitizeLanguageParamOptions(params, languageParamIndex) {
     const languageOption = this.validateLanguageOption(params, languageParamIndex);
     const languageConfig = [`-l ${languageOption}`];
-    this.removeLanguageParameters(params, languageParamIndex);
+    this.removeParameterAtIndex(params, languageParamIndex);
     return [...params, ...languageConfig];
   }
 
@@ -59,8 +64,18 @@ export class ParametersParser {
     return languageOption;
   }
 
-  static removeLanguageParameters(params, languageParamIndex) {
+  static removeParameterAtIndex(params, languageParamIndex) {
     params.splice(languageParamIndex, 2);
+  }
+
+  static sanitizeDirectoryParamOptions(params, directoryParamIndex) {
+    const directoryOption = params[directoryParamIndex + 1]
+    if(directoryOption === undefined) {
+      throw new ConfigurationParsingError('Must send a route for --directory option')
+    }
+    const directoryConfig = [`-d ${directoryOption}`];
+    this.removeParameterAtIndex(params, directoryParamIndex);
+    return [...params, ...directoryConfig];
   }
 
   static validateConfigurationParams(paramsList) {
@@ -69,7 +84,10 @@ export class ParametersParser {
         this.validateLanguageOption(paramsList, index);
       }
 
-      if (!this.isRawConfigurationParam(param)) {
+      const previousParam = paramsList[index - 1]
+      const previousParamIsDirectoryFlag = previousParam === '-d' || previousParam === '--directory'
+
+      if (!this.isRawConfigurationParam(param) && !previousParamIsDirectoryFlag) {
         throw new ConfigurationParsingError('Run configuration parameters should always be sent at the end of test paths routes');
       }
     });
@@ -113,6 +131,11 @@ export class ParametersParser {
     return this.#matchesStringParam(options[0], '-l', '--language');
   };
 
+  static isDirectoryParam(paramExpression) {
+    const options = paramExpression.split(' ');
+    return this.#matchesStringParam(options[0], '-d', '--directory');
+  }
+
   static #matchesStringParam(param, ...strings) {
     return isString(param) && strings.includes(param);
   }
@@ -149,6 +172,18 @@ class LanguageConfigurationParameterParser {
   static handle(consoleParam) {
     const options = consoleParam.split(' ');
     return { language: options[1] };
+  }
+}
+
+class DirectoryConfigurationParameterParser {
+
+  static canHandle(consoleParam) {
+    return ParametersParser.isDirectoryParam(consoleParam);
+  }
+
+  static handle(consoleParam) {
+    const options = consoleParam.split(' ');
+    return { directory: options[1] };
   }
 }
 

--- a/lib/config/parameters_parser.js
+++ b/lib/config/parameters_parser.js
@@ -1,5 +1,5 @@
 import { I18n } from '../i18n/i18n.js';
-import { isString } from '../utils.js';
+import { isString, isUndefined } from '../utils.js';
 import { ConfigurationParsingError } from '../errors.js';
 
 /**
@@ -74,7 +74,7 @@ export class ParametersParser {
 
   static sanitizeDirectoryParamOptions(params, directoryParamIndex) {
     const directoryOption = params[directoryParamIndex + 1];
-    if (directoryOption === undefined) {
+    if (isUndefined(directoryOption)) {
       throw new ConfigurationParsingError('Must send a route for --directory option');
     }
     const directoryConfig = [`-d ${directoryOption}`];

--- a/lib/config/parameters_parser.js
+++ b/lib/config/parameters_parser.js
@@ -37,15 +37,19 @@ export class ParametersParser {
   }
 
   static sanitizeParameters(params) {
+    let sanitizedParams = params
+
     const languageParamIndex = params.findIndex(param => param === '-l' || param === '--language');
-    const directoryParamIndex = params.findIndex(param => param === '-d' || param === '--directory');
     if (languageParamIndex >= 0) {
-      return this.sanitizeLanguageParamOptions(params, languageParamIndex);
+      sanitizedParams = this.sanitizeLanguageParamOptions(sanitizedParams, languageParamIndex);
     }
+
+    const directoryParamIndex = params.findIndex(param => param === '-d' || param === '--directory');
     if (directoryParamIndex >= 0) {
-      return this.sanitizeDirectoryParamOptions(params, directoryParamIndex);
+      sanitizedParams = this.sanitizeDirectoryParamOptions(sanitizedParams, directoryParamIndex);
     }
-    return params;
+
+    return sanitizedParams;
   }
 
   static sanitizeLanguageParamOptions(params, languageParamIndex) {

--- a/lib/script_action.js
+++ b/lib/script_action.js
@@ -89,11 +89,12 @@ Usage:
    testy [-h --help] [-v --version] ...test files or folders...
 
 Options: 
-   -h, --help        Displays this text
-   -v, --version     Displays the current version
-   -f, --fail-fast   Enables fail fast option for running tests
-   -r, --randomize   Enables random order option for running tests
-   -l, --language xx Sets a language for running tests. Available options are 'es' for Spanish, 'en' for English and 'it' for Italian
+   -h, --help             Displays this text
+   -v, --version          Displays the current version
+   -f, --fail-fast        Enables fail fast option for running tests
+   -r, --randomize        Enables random order option for running tests
+   -l, --language xx      Sets a language for running tests. Available options are 'es' for Spanish, 'en' for English and 'it' for Italian
+   -d, --directory route  Sets the parent directory for running tests. If explicit test routes are provided, this last ones will be prioritized over the set directory.
   `);
     this._exitSuccessfully();
   }

--- a/tests/configuration/parameters_parser_test.js
+++ b/tests/configuration/parameters_parser_test.js
@@ -162,8 +162,8 @@ suite('Parameters parser', () => {
 
   test('throws an error when directory parameter does not have an argument', () => {
     assert
-        .that(() => ParametersParser.sanitizeParameters(['-d']))
-        .raises(new ConfigurationParsingError('Must send a route for --directory option'));
+      .that(() => ParametersParser.sanitizeParameters(['-d']))
+      .raises(new ConfigurationParsingError('Must send a route for --directory option'));
   });
 
   test('validateConfigurationParams fails if a path param is sent', () => {


### PR DESCRIPTION
## What

This PR introduces the ability to set up the directory configuration param through the console. Options are `--directory route` or `-d route`. If explicit test paths are passed in when doing npx testy (i.e `npx testy /my/test/route --directory /another/route`), the directory flag valuewill be ignored. Otherwise, all tests within the route argument of the directory parameter will be executed. 

This parameter can be used in combination with the existing ones.


https://github.com/user-attachments/assets/a591e35b-7441-47f7-90d5-3138c8754edc


