### PR TITLE
[Feature ✨] Adding extension filter flag

### DIFF
--- a/lib/config/parameters_parser.js
+++ b/lib/config/parameters_parser.js
@@ -29,6 +29,7 @@ export class ParametersParser {
       RandomizeConfigurationParameterParser,
       LanguageConfigurationParameterParser,
       DirectoryConfigurationParameterParser,
+      FileExtensionConfigurationParameterParser,
       InvalidConfigurationParameter,
     ].find(configurationParameterParser =>
       configurationParameterParser.canHandle(param),
@@ -46,7 +47,12 @@ export class ParametersParser {
 
     const directoryParamIndex = params.findIndex(param => param === '-d' || param === '--directory');
     if (directoryParamIndex >= 0) {
-      sanitizedParams = this.sanitizeDirectoryParamOptions(sanitizedParams, directoryParamIndex);
+      sanitizedParams = this.sanitizeParamWithArgument(sanitizedParams, directoryParamIndex, '-d')
+    }
+
+    const fileExtensionParamIndex = params.findIndex(param => param === '-e' || param === '--extension');
+    if (fileExtensionParamIndex >= 0) {
+      sanitizedParams = this.sanitizeParamWithArgument(sanitizedParams, fileExtensionParamIndex, '-e')
     }
 
     return sanitizedParams;
@@ -72,26 +78,27 @@ export class ParametersParser {
     params.splice(languageParamIndex, 2);
   }
 
-  static sanitizeDirectoryParamOptions(params, directoryParamIndex) {
-    const directoryOption = params[directoryParamIndex + 1];
-    if (isUndefined(directoryOption)) {
-      throw new ConfigurationParsingError('Must send a route for --directory option');
+  static sanitizeParamWithArgument(params, paramWithArgumentIndex, paramName) {
+    const paramOption = params[paramWithArgumentIndex + 1];
+    if (isUndefined(paramOption)) {
+      throw new ConfigurationParsingError(`Must send a route for ${paramName} option`);
     }
-    const directoryConfig = [`-d ${directoryOption}`];
-    this.removeParameterAtIndex(params, directoryParamIndex);
-    return [...params, ...directoryConfig];
+    const paramConfig = [`${paramName} ${paramOption}`];
+    this.removeParameterAtIndex(params, paramWithArgumentIndex);
+    return [...params, ...paramConfig];
   }
 
   static validateConfigurationParams(paramsList) {
     paramsList.forEach((param, index) => {
-      if (this.isLanguageParam(param)) {
+      if (this.isParamWithArgument(param, ['-l', '--language'])) {
         this.validateLanguageOption(paramsList, index);
       }
 
       const previousParam = paramsList[index - 1];
       const previousParamIsDirectoryFlag = previousParam === '-d' || previousParam === '--directory';
+      const previousParamIsFileExtensionFlag = previousParam === '-e' || previousParam === '--extension';
 
-      if (!this.isRawConfigurationParam(param) && !previousParamIsDirectoryFlag) {
+      if (!this.isRawConfigurationParam(param) && !previousParamIsDirectoryFlag && !previousParamIsFileExtensionFlag) {
         throw new ConfigurationParsingError('Run configuration parameters should always be sent at the end of test paths routes');
       }
     });
@@ -130,14 +137,9 @@ export class ParametersParser {
     return this.#matchesStringParam(string, '-r', '--randomize');
   }
 
-  static isLanguageParam(paramExpression) {
+  static isParamWithArgument(paramExpression, expectedParams) {
     const options = paramExpression.split(' ');
-    return this.#matchesStringParam(options[0], '-l', '--language');
-  };
-
-  static isDirectoryParam(paramExpression) {
-    const options = paramExpression.split(' ');
-    return this.#matchesStringParam(options[0], '-d', '--directory');
+    return this.#matchesStringParam(options[0], ...expectedParams);
   }
 
   static #matchesStringParam(param, ...strings) {
@@ -170,7 +172,7 @@ class RandomizeConfigurationParameterParser {
 class LanguageConfigurationParameterParser {
 
   static canHandle(consoleParam) {
-    return ParametersParser.isLanguageParam(consoleParam);
+    return ParametersParser.isParamWithArgument(consoleParam, ['-l', '--language']);
   }
 
   static handle(consoleParam) {
@@ -182,12 +184,24 @@ class LanguageConfigurationParameterParser {
 class DirectoryConfigurationParameterParser {
 
   static canHandle(consoleParam) {
-    return ParametersParser.isDirectoryParam(consoleParam);
+    return ParametersParser.isParamWithArgument(consoleParam, ['-d', '--directory']);
   }
 
   static handle(consoleParam) {
     const options = consoleParam.split(' ');
     return { directory: options[1] };
+  }
+}
+
+class FileExtensionConfigurationParameterParser {
+
+  static canHandle(consoleParam) {
+    return ParametersParser.isParamWithArgument(consoleParam, ['-e', '--extension']);
+  }
+
+  static handle(consoleParam) {
+    const options = consoleParam.split(' ');
+    return { filter: options[1] };
   }
 }
 

--- a/tests/configuration/parameters_parser_test.js
+++ b/tests/configuration/parameters_parser_test.js
@@ -45,16 +45,28 @@ suite('Parameters parser', () => {
     assert.areEqual(configuration, { directory: './my_tests' });
   });
 
-  test('returns configuration with specific directory is passing -d option', () => {
+  test('returns configuration with specific directory if passing -d option', () => {
     const configuration = ParametersParser.generateRunConfigurationFromParams(['-d ./my_tests']);
     assert.areEqual(configuration, { directory: './my_tests' });
   });
+
+  test('returns configuration with specific file extension if passing --extension option', () => {
+    const configuration = ParametersParser.generateRunConfigurationFromParams(['--extension .*_test.rb$']);
+    assert.areEqual(configuration, { filter: '.*_test.rb$' });
+  });
+
+  test('returns configuration with specific file extension if passing --e option', () => {
+    const configuration = ParametersParser.generateRunConfigurationFromParams(['-e .*_test.rb$']);
+    assert.areEqual(configuration, { filter: '.*_test.rb$' });
+  });
+
 
   test('returns configuration with fail fast, randomize and english language enabled when mixing long and short commands no matter the order the params are sent', () => {
     const configuration1 = ParametersParser.generateRunConfigurationFromParams(['-f', '--randomize', '-l en']);
     const configuration2 = ParametersParser.generateRunConfigurationFromParams(['--fail-fast', '-l en', '-r']);
     const configuration3 = ParametersParser.generateRunConfigurationFromParams(['--language en', '-f', '-r']);
     const configuration4 = ParametersParser.generateRunConfigurationFromParams(['--directory ./a_directory', '-l it', '-r']);
+    const configuration5 = ParametersParser.generateRunConfigurationFromParams(['--extension .*_test.rb$', '-l it', '-r']);
 
     assert.areEqual(configuration1, {
       failFast: true,
@@ -73,6 +85,11 @@ suite('Parameters parser', () => {
     });
     assert.areEqual(configuration4, {
       directory: './a_directory',
+      randomOrder: true,
+      language: 'it',
+    });
+    assert.areEqual(configuration5, {
+      filter: '.*_test.rb$',
       randomOrder: true,
       language: 'it',
     });
@@ -148,6 +165,11 @@ suite('Parameters parser', () => {
     assert.areEqual(sanitizedParams, ['-f', '-r', '-d ./a_directory']);
   });
 
+  test('returns sanitized params when passing a valid list of params including extension params', () => {
+    const sanitizedParams = ParametersParser.sanitizeParameters(['-f', '-d', './a_directory', '-r', '--extension', '.*_test.rb$']);
+    assert.areEqual(sanitizedParams, ['-f', '-r', '-d ./a_directory', '-e .*_test.rb$']);
+  });
+
   test('throws an error when sending invalid language option', () => {
     assert
       .that(() => ParametersParser.sanitizeParameters(['-l', 'fakeLanguage']))
@@ -163,7 +185,13 @@ suite('Parameters parser', () => {
   test('throws an error when directory parameter does not have an argument', () => {
     assert
       .that(() => ParametersParser.sanitizeParameters(['-d']))
-      .raises(new ConfigurationParsingError('Must send a route for --directory option'));
+      .raises(new ConfigurationParsingError('Must send a route for -d option'));
+  });
+
+  test('throws an error when extension parameter does not have an argument', () => {
+    assert
+        .that(() => ParametersParser.sanitizeParameters(['-e']))
+        .raises(new ConfigurationParsingError('Must send a route for -e option'));
   });
 
   test('validateConfigurationParams fails if a path param is sent', () => {


### PR DESCRIPTION
## What

This PR introduces the ability to set up the filter configuration param through the console. Options are `--extension filter` or `-e filter`. 
- If passing both a test path and an extension, the test will only be executed if it matches that extension
<img width="749" alt="image" src="https://github.com/user-attachments/assets/6d9bae28-1073-4866-8d93-4f645f7d8e51" />
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/a9dd0dd3-9779-4af9-8ee6-a2a9f4389e41" />

- If no extension is passed in, it default to the one specified in `testyrc.json` file, and lastly to the one in `default_configuration.json`

- If running all tests passing an extension, only the tests matching the extension will be executed 
<img width="920" alt="image" src="https://github.com/user-attachments/assets/26d5c11f-009c-4085-a967-94217d0b1ab8" />

Can be combined with --directory option 
<img width="640" alt="image" src="https://github.com/user-attachments/assets/0c7ded5a-9522-41a5-bfb0-301e5b15a8d7" />


## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)
