### PR TITLE
Adding missing description to READMEs and help command for extension parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ test file path:
 - `-r` or `--randomize` to enable the execution of tests in random order.
 - `-l xx` or `--language xx` where `xx` must be either `es` for Spanish, `en` for English or `it` for Italian.
 - `-d route` or `--directory route` where `route` must be a directory that contains test files. If explicit test routes are provided, this directory parameter will be ignored.
+- `-e filter` or `--extension filter` where `filter` is the extension (suffix) of the test files you want to run.
 
 These console parameters can be sent in any order and combined as you want.
 

--- a/README_es.md
+++ b/README_es.md
@@ -125,6 +125,7 @@ que quieras ejecutar:
 - `-r` o `--randomize` para habilitar la ejecución de tests en orden aleatorio.
 - `-l xx` o `--language xx` done `xx` debe ser `es` para español, `en` para inglés o `it` para italiano.
 - `-d ruta` or `--directory ruta` donde `ruta` debe ser un directorio que contiene archivos de test. Si se proveen rutas explicitas de tests para ejecutar, este parametro será ignorado.
+- `-e filtro` or `--extension filtro` donde `filtro` es la extension (sufijo) de los tests que se quieren ejecutar.
 
 Estos parámetros por consola pueden ser enviados en el orden que desees y puedes combinarlos como quieras. Toman
 precedencia respecto a los que estén configurados en `.testyrc.json`.

--- a/lib/script_action.js
+++ b/lib/script_action.js
@@ -89,12 +89,13 @@ Usage:
    testy [-h --help] [-v --version] ...test files or folders...
 
 Options: 
-   -h, --help             Displays this text
-   -v, --version          Displays the current version
-   -f, --fail-fast        Enables fail fast option for running tests
-   -r, --randomize        Enables random order option for running tests
-   -l, --language xx      Sets a language for running tests. Available options are 'es' for Spanish, 'en' for English and 'it' for Italian
-   -d, --directory route  Sets the parent directory for running tests. If explicit test routes are provided, this last ones will be prioritized over the set directory.
+   -h, --help              Displays this text
+   -v, --version           Displays the current version
+   -f, --fail-fast         Enables fail fast option for running tests
+   -r, --randomize         Enables random order option for running tests
+   -l, --language xx       Sets a language for running tests. Available options are 'es' for Spanish, 'en' for English and 'it' for Italian
+   -d, --directory route   Sets the parent directory for running tests. If explicit test routes are provided, this last ones will be prioritized over the set directory.
+   -e, --extension filter  Sets the filter extension for running tests. Only tests with names matching this suffix will be executed.
   `);
     this._exitSuccessfully();
   }


### PR DESCRIPTION

## What

Forgot to add --extension flag documentation when I posted https://github.com/ngarbezza/testy/pull/344