### PR TITLE
Migrate from Renovate to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "08:00"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "08:00"
+    cooldown:
+      default-days: 5
+    commit-message:
+      prefix: "chore(deps)"

--- a/doc/ai-ideas.md
+++ b/doc/ai-ideas.md
@@ -53,7 +53,7 @@ escribe los tests, el alumno no aprende). Las ideas más interesantes respetan e
   patrones existentes ("no dark magic").
 - **Guardián de simplicidad**: bloquea/avisa en CI cuando un PR agrega dependencias, sube
   complejidad o introduce magia. Defiende el valor #1 del proyecto.
-- **Triage de Renovate**: evaluar si un bump de dependencia/Node es seguro de mergear.
+- **Triage de Dependabot**: evaluar si un bump de dependencia/Node es seguro de mergear.
 
 ### Meta: toolkit de desarrollo con AI
 - **`CLAUDE.md` + skills propias de Testy**: que cualquier maintainer/contributor tenga un

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## What

Replace Mend Renovate with GitHub's native Dependabot for automated dependency updates. This removes `renovate.json` and introduces `.github/dependabot.yml` covering two ecosystems:

- **npm** — weekly updates (Tuesdays 08:00), semver-aware cooldown (patch: 3d / minor: 7d / major: 30d), commit prefixes `chore(deps)` / `chore(deps-dev)`
- **github-actions** — same weekly schedule, 5-day cooldown, prefix `chore(deps)`

The setup mirrors the one used in radar-backend. Also updates a reference in `doc/ai-ideas.md` from "Triage de Renovate" to "Triage de Dependabot".

## Link to issue(s)

- [[refactoring] replace Mend Renovate for Github Actions](https://github.com/ngarbezza/testy/issues/266)

## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)