### PR TITLE
AI roadmap (fase 0): CLAUDE.md + skills propias del proyecto (#381)

### DIFF
--- a/.claude/skills/add-assertion/SKILL.md
+++ b/.claude/skills/add-assertion/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: Agregar assertion
+description: Guía conversacional para agregar una nueva assertion a Testy siguiendo el ADN del proyecto (zero-dependency, OO puro, self-testing obligatorio).
+disable-model-invocation: true
+---
+
+# Agregar una nueva assertion a Testy
+
+Sos un experto en la arquitectura de Testy y vas a guiar al contributor paso a paso.
+Seguí el flujo en orden. No avances al siguiente paso sin confirmar el anterior.
+
+## Paso 1 — Entender la necesidad
+
+Preguntale al usuario:
+1. ¿Qué assertion quiere agregar? (nombre tentativo y qué verifica)
+2. ¿Cuál es el caso de uso concreto? (un ejemplo de cómo se usaría en un test)
+
+Esperá la respuesta antes de continuar.
+
+## Paso 2 — Leer el contexto existente
+
+Lee `lib/core/assertion.js` y `lib/core/asserter.js`.
+
+Verificá:
+- ¿Ya existe una assertion equivalente o muy similar? Si sí, señalásela al usuario y preguntá si realmente hace falta una nueva.
+- ¿Cuál es el patrón que siguen las assertions existentes? (nombre, firma, mensajes de fallo)
+
+## Paso 3 — Implementación guiada
+
+Guiá la implementación en este orden:
+
+### 3a. Método en `lib/core/assertion.js`
+
+- Nombre descriptivo en inglés, que lea como una oración (ej: `isGreaterThan`, `includesExactly`).
+- Método de instancia. Sin `static`. Sin condicionales sobre tipos.
+- Si el fallo necesita un mensaje personalizado: usá `I18nMessage.of('clave')`. Lee `lib/i18n/translations.json` para ver el patrón.
+
+**Guardián del ADN:** si el usuario propone algo que requiera una dependencia externa, use `typeof` de forma masiva, haga duck-typing con `instanceof` sobre muchos tipos, o implemente lógica que ya existe en otra assertion, rechazalo y explicá por qué rompe el ADN.
+
+### 3b. Shorthand en `lib/core/asserter.js` (opcional)
+
+Preguntale al usuario si quiere un shorthand (ej: `assert.isGreaterThan(a, b)` además de `assert.that(a).isGreaterThan(b)`).
+
+Si sí: agregá el método delegando a `this.that(actual).<assertion>(expected)`. Sin lógica propia en el shorthand.
+
+### 3c. Traducciones en `lib/i18n/translations.json` (si aplica)
+
+Si el mensaje de fallo usa una clave nueva, agregala en los **4 idiomas**: `en`, `es`, `it`, `pt`.
+
+El test `tests/core/translation_keys_consistency_test.js` falla si falta alguno — recordáselo al usuario.
+
+## Paso 4 — Self-testing obligatorio
+
+Recordale al usuario que **el test es obligatorio**. Guiá la creación del test en `tests/core/`:
+
+- Usá los helpers de `tests/support/tests_factory.js` como referencia para crear instancias de test.
+- Un test por comportamiento: qué pasa cuando pasa, qué pasa cuando falla, qué mensaje de error se muestra.
+
+Pedile que corra:
+
+```bash
+npm test
+```
+
+No des la tarea por terminada hasta confirmar que todos los tests pasan.
+
+## Paso 5 — Cierre
+
+Preguntale al usuario:
+- ¿Actualizó la sección `## Extending the framework` del CLAUDE.md si la assertion es relevante?
+- ¿El PR tiene un solo concepto y viene con tests?
+
+Recordale el mandato del proyecto: *simple, legible, sin magia*.

--- a/.claude/skills/add-assertion/SKILL.md
+++ b/.claude/skills/add-assertion/SKILL.md
@@ -35,11 +35,11 @@ Guiá la implementación en este orden:
 - Método de instancia. Sin `static`. Sin condicionales sobre tipos.
 - Si el fallo necesita un mensaje personalizado: usá `I18nMessage.of('clave')`. Lee `lib/i18n/translations.json` para ver el patrón.
 
-**Guardián del ADN:** si el usuario propone algo que requiera una dependencia externa, use `typeof` de forma masiva, haga duck-typing con `instanceof` sobre muchos tipos, o implemente lógica que ya existe en otra assertion, rechazalo y explicá por qué rompe el ADN.
+**Guardián del ADN:** si el usuario propone algo que requiera una dependencia externa, use `typeof` de forma masiva, haga duck-typing con `instanceof` sobre muchos tipos, o implemente lógica que ya existe en otra assertion, rechazalo y explicá por qué rompe el ADN. Además: no usés `for...of` ni `for...in` en `lib/` (ESLint lo rechaza; usá métodos de array). Para errores de precondición de tipo, usá solo `InvalidAssertionError` (no lances `Error` genérico ni uses assertions de tipo).
 
 ### 3b. Shorthand en `lib/core/asserter.js` (opcional)
 
-Preguntale al usuario si quiere un shorthand (ej: `assert.isGreaterThan(a, b)` además de `assert.that(a).isGreaterThan(b)`).
+Preguntale al usuario si quiere un shorthand. Antes de decidir, guialo con este criterio: un shorthand es apropiado solo cuando la assertion tiene uno o dos argumentos fijos y se lee bien como método directo en `Asserter` (ej: `assert.areEqual(a, b)`). Si la assertion tiene más argumentos o se lee mejor encadenada, el shorthand no agrega valor.
 
 Si sí: agregá el método delegando a `this.that(actual).<assertion>(expected)`. Sin lógica propia en el shorthand.
 
@@ -53,7 +53,13 @@ El test `tests/core/translation_keys_consistency_test.js` falla si falta alguno 
 
 Recordale al usuario que **el test es obligatorio**. Guiá la creación del test en `tests/core/`:
 
-- Usá los helpers de `tests/support/tests_factory.js` como referencia para crear instancias de test.
+- Los tests de assertions viven en `tests/core/assertions/`. Usá `tests/support/runner_helpers.js` (`resultOfATestWith`) y `tests/support/assertion_helpers.js` (`expectSuccess`, `expectFailureOn`, `expectErrorOn`) como infraestructura. Ejemplo de patrón:
+
+```js
+const result = await resultOfATestWith(assert => assert.that(actual).tuNuevaAssertion(expected));
+expectSuccess(result); // o expectFailureOn(result, mensajeEsperado)
+```
+
 - Un test por comportamiento: qué pasa cuando pasa, qué pasa cuando falla, qué mensaje de error se muestra.
 
 Pedile que corra:
@@ -67,7 +73,7 @@ No des la tarea por terminada hasta confirmar que todos los tests pasan.
 ## Paso 5 — Cierre
 
 Preguntale al usuario:
-- ¿Actualizó la sección `## Extending the framework` del CLAUDE.md si la assertion es relevante?
+- ¿Agregó JSDoc al método nuevo en `assertion.js`? Todos los métodos públicos deben tener `@example`, `@param` y `@returns`.
 - ¿El PR tiene un solo concepto y viene con tests?
 
 Recordale el mandato del proyecto: *simple, legible, sin magia*.

--- a/.claude/skills/add-assertion/SKILL.md
+++ b/.claude/skills/add-assertion/SKILL.md
@@ -73,7 +73,7 @@ No des la tarea por terminada hasta confirmar que todos los tests pasan.
 ## Paso 5 — Cierre
 
 Preguntale al usuario:
-- ¿Agregó JSDoc al método nuevo en `assertion.js`? Todos los métodos públicos deben tener `@example`, `@param` y `@returns`.
+- ¿Agregó JSDoc al método nuevo en `assertion.js`? Todos los métodos públicos deben tener `@example` y `@returns`; usar `@param` para cada argumento cuando la assertion recibe parámetros.
 - ¿El PR tiene un solo concepto y viene con tests?
 
 Recordale el mandato del proyecto: *simple, legible, sin magia*.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,14 @@ Node 22+ is required. The repo uses asdf; `.tool-versions` pins `nodejs 22.21.0`
 **New output format:** create a subclass of `Formatter`, override the event methods you need, register it in `FormatterFactory`.
 
 **New i18n message:** add the key to all four language sections in `lib/i18n/translations.json`, then use `I18nMessage.of('key')` or `this.translated('key')` in a formatter.
+
+## Contributing conventions
+
+- **Self-testing is mandatory** — every feature or fix must be accompanied by a test in `tests/`. If Testy cannot test its own change, something is wrong with the design.
+- **One PR, one concept** — no opportunistic refactors bundled in the same PR.
+- **Extra quality commands:**
+
+```bash
+npm run test:coverage   # coverage report via c8
+npm run test:mutation   # mutation testing via Stryker
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 These values act as a filter for every proposed change. Reject anything that violates them.
 
-- **Zero dependencies** — no runtime npm dependencies, ever (see `doc/decisions/0003-zero-dependencies.md`). Refuse any change that adds an `import` from an external package.
+- **Zero dependencies** — no runtime npm dependencies in library code (see `doc/decisions/0003-zero-dependencies.md`). Refuse any change that adds an `import` from an external package inside `lib/` or `bin/`.
 - **No dark magic** — no Proxies, no monkey-patching, no metaprogramming. Every line must be readable in a classroom without prior explanation.
 - **OOP in the Smalltalk spirit** — behaviour through message sends and polymorphism, not conditionals over types. Add a method to an object before adding a `switch`/`if` chain in a caller.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ npm run lint:fix                  # ESLint auto-fix
 npm run playground:reset          # copy template → tests/playground_test.js
 npm run playground:run            # run playground file
 npm run playground:clear          # delete playground file
+npm run test:coverage              # coverage report via c8 (see reports/coverage/)
+npm run test:mutation              # mutation testing via Stryker (slow, see reports/mutation/)
 ```
 
 Node 22+ is required. The repo uses asdf; `.tool-versions` pins `nodejs 22.21.0`.
@@ -87,9 +89,4 @@ Node 22+ is required. The repo uses asdf; `.tool-versions` pins `nodejs 22.21.0`
 
 - **Self-testing is mandatory** — every feature or fix must be accompanied by a test in `tests/`. If Testy cannot test its own change, something is wrong with the design.
 - **One PR, one concept** — no opportunistic refactors bundled in the same PR.
-- **Extra quality commands:**
-
-```bash
-npm run test:coverage   # coverage report via c8
-npm run test:mutation   # mutation testing via Stryker
-```
+- **Run `npm test` and `npm run lint` before opening a PR** — CI will catch failures, but it's faster to catch them locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ npm run lint:fix                  # ESLint auto-fix
 npm run playground:reset          # copy template → tests/playground_test.js
 npm run playground:run            # run playground file
 npm run playground:clear          # delete playground file
-npm run test:coverage              # coverage report via c8 (see reports/coverage/)
-npm run test:mutation              # mutation testing via Stryker (slow, see reports/mutation/)
+npm run test:coverage             # coverage report via c8 (see reports/coverage/)
+npm run test:mutation             # mutation testing via Stryker (slow, see reports/mutation/)
 ```
 
 Node 22+ is required. The repo uses asdf; `.tool-versions` pins `nodejs 22.21.0`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Project DNA
+
+These values act as a filter for every proposed change. Reject anything that violates them.
+
+- **Zero dependencies** — no runtime npm dependencies, ever (see `doc/decisions/0003-zero-dependencies.md`). Refuse any change that adds an `import` from an external package.
+- **No dark magic** — no Proxies, no monkey-patching, no metaprogramming. Every line must be readable in a classroom without prior explanation.
+- **OOP in the Smalltalk spirit** — behaviour through message sends and polymorphism, not conditionals over types. Add a method to an object before adding a `switch`/`if` chain in a caller.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `## Project DNA` section to `CLAUDE.md` with the three core values of the project: zero-dependency (scoped to `lib/` and `bin/`), no dark magic, and OOP in the Smalltalk spirit. Acts as a filter for AI assistants and contributors.
- Add `## Contributing conventions` section to `CLAUDE.md` with: mandatory self-testing, one PR one concept, and the gate to run `npm test` + `npm run lint` before opening a PR.
- Add `npm run test:coverage` and `npm run test:mutation` to the `## Commands` section.
- Create `.claude/skills/add-assertion/SKILL.md`: a conversational 5-step skill (`/add-assertion`) that guides contributors through adding a new assertion — from understanding the need to self-testing — while enforcing the project's DNA at every step.

Closes #381.

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Verify `.claude/skills/add-assertion/SKILL.md` is invocable as `/add-assertion` in a Claude Code session on this repo
- [ ] Run `npm test` to confirm no regressions
- [ ] Run `npm run lint` to confirm no linting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)