### PR TITLE
Use node: prefix in json_formatter.js module import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ tests/playground_test.js
 
 # Implementation plans (AI-assisted, ephemeral)
 doc/plans/
+
+# Git worktrees
+.worktrees/

--- a/lib/ui/json_formatter.js
+++ b/lib/ui/json_formatter.js
@@ -1,4 +1,4 @@
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
 import { Formatter } from './formatter.js';
 
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary

- Replaces `'module'` with `'node:module'` in the `createRequire` import in `lib/ui/json_formatter.js`
- Aligns with the canonical `node:` prefix convention already used throughout the codebase (`bin/simplicity-guardian.js`, `bin/testy_cli.js`)

## Test plan

- [x] `npm test` — 410/410 tests pass
- [x] `npm run lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)