### PR TITLE
ci: migrate deprecated SonarCloud action to sonarqube-scan-action

### DIFF
--- a/.github/workflows/node_ci.yml
+++ b/.github/workflows/node_ci.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           coverage_files: reports/coverage/lcov.info
       - if: matrix.node-version == '20.x'
-        name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
         with:
           args: >
             -Dsonar.projectKey=ngarbezza_testy
@@ -48,3 +48,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary
- `SonarSource/sonarcloud-github-action` está deprecada; se reemplaza por la action unificada `SonarSource/sonarqube-scan-action@v6`.
- Se agrega `SONAR_HOST_URL: https://sonarcloud.io` en el env del step, requerido porque la nueva action por defecto apunta a un SonarQube Server propio en lugar de SonarCloud.

## Test plan
- [x] `npm run lint` pasa
- [x] `npm test` pasa (410 tests)
- [ ] Verificar en CI que el step de Sonar corre correctamente contra SonarCloud