### PR TITLE
Host capability catalog (ADR 0018) + Clock host role

### DIFF
--- a/doc/decisions/0017-host-capability-catalog.md
+++ b/doc/decisions/0017-host-capability-catalog.md
@@ -1,0 +1,112 @@
+# 17. Host capability catalog
+
+Date: 2026-07-22
+
+## Status
+
+Accepted
+
+## Context
+
+Testy wants to decouple itself from the specific language and runtime it happens
+to run on, so that porting it to another language becomes a matter of design
+translation rather than archaeology.
+
+Today the coupling to Node internals is scattered but small (around seven contact
+points). The valuable artifact for a port is **not** a JavaScript wrapper over
+`fs` or `console` — that code is thrown away when the framework is rewritten in
+another language. What survives the port is knowing *what Testy needs from its
+host*: the set of capabilities the core relies on, named in domain terms.
+
+This decision names that set. It builds on existing decisions:
+
+- 0003 (zero dependencies) — we already reimplement host-adjacent helpers rather
+  than pulling packages, so isolating them is consistent.
+- 0002 (utilities in the `Utils` module) — reimplementable algorithms already live
+  there.
+- 0004 (console UI and formatter) — `console` and `process` are already injected
+  into `ConsoleUI`/`Formatter`, so there is precedent for treating host access as
+  an injected collaborator rather than a direct dependency.
+
+## Decision
+
+Treat the capabilities Testy requires from its host as an **explicit, named
+contract** — the portability seam. The core is defined in terms of *what it needs
+from the host*, not in terms of the Node API names that currently satisfy those
+needs.
+
+Capabilities are classified into two kinds, because they port very differently:
+
+### Host services (I/O; runtime-dependent; injectable)
+
+Behaviour that talks to the outside world. It changes per runtime (Node, Deno,
+Bun, browser) and is a natural injection point for fakes in Testy's own tests.
+
+1. **File discovery** — find the files matching a pattern under a directory.
+   Today: `lib/utils/files.js` (`allFilesMatching`, `resolvePathFor`) via
+   `fs.lstatSync`, `fs.readdirSync`, `path.join`/`path.resolve`, `process.cwd()`.
+2. **File removal** — delete a temporary file.
+   Today: `lib/testy.js` (`fs.unlinkSync`) and the TypeScript cache directory.
+3. **Output sink** — print lines and emit timing marks.
+   Today: `lib/ui/formatter.js` via `console.log`/`console.time`/`console.timeEnd`.
+4. **Process control** — terminate with an exit code and read CLI arguments.
+   Today: `lib/ui/console_ui.js` (`process.exit`) and `bin/testy_cli.js`
+   (`process.argv`).
+5. **Clock** — obtain the current time in milliseconds.
+   Today: `lib/ui/tap_formatter.js` and `lib/ui/json_formatter.js` via `Date.now()`.
+6. **Test module loading** — load and evaluate a test file given its path, and
+   read JSON documents (configuration, translations, `package.json`).
+   Today: dynamic `import()` + `pathToFileURL` and `createRequire` across
+   `lib/testy.js`, `lib/config/configuration.js`, `lib/i18n/i18n.js`,
+   `lib/script_action.js`, `lib/ui/json_formatter.js`.
+   **This is the hardest seam and the least portable capability**: loading and
+   evaluating a test file is intrinsically language-specific. Naming it isolates
+   it; it does not make it abstract.
+
+### Reimplementable semantics (algorithms; rewritten per language)
+
+Pure computations, not I/O. A port reimplements these directly in the target
+language; there is nothing to inject.
+
+1. **Deep structural equality** — compare two values by structure.
+   Today: `lib/utils/comparison.js` via `util.isDeepStrictEqual`.
+2. **Object inspection / string representation** — render a value as a
+   human-readable string for output.
+   Today: `lib/utils/formatting.js` via `util.inspect`.
+
+### Design rules
+
+- Name each capability in **domain verbs** (`allFilesMatching`, "print a line"),
+  never as a one-to-one passthrough of the Node API (`readdirSync`, `lstatSync`).
+  A thin passthrough adds indirection without value; the contract must describe
+  what Testy needs, not what Node offers.
+- Keep host services behind **injectable collaborators**, following the precedent
+  of 0004.
+- Keep reimplementable semantics isolated in `Utils`, so a port can rewrite them
+  without touching the core.
+
+This decision does **not** commit to the concrete shape of a `Platform` /
+`Environment` object. It fixes the contract and the classification; the concrete
+injection design is deferred to its own decision.
+
+### Out of scope
+
+The TypeScript transpiler (`lib/typescript/`) is a host-specific extension, not
+part of the portable core. A port is not expected to reproduce it.
+
+## Consequences
+
+1. A language port has a concrete checklist: implement N host services plus M
+   reimplementable algorithms, and provide a test-loading mechanism for the target
+   language.
+2. Testability improves: host services can be faked in Testy's own tests, which is
+   itself the proof that the seam is real.
+3. Portability across JavaScript runtimes (Deno, Bun, browser, workers) improves
+   for free, since the core stops naming Node modules directly.
+4. Test module loading remains a **known boundary**: it is named but not made
+   portable, and every port must solve it in its own terms.
+5. There is an indirection cost. It is mitigated by defining the contract in domain
+   verbs rather than mirroring the Node API.
+6. The direction is consistent with the project DNA (zero dependencies, no dark
+   magic, message-sends over conditionals) and with the injection already present
+   in the console/formatter layer.

--- a/doc/decisions/0018-host-capability-catalog.md
+++ b/doc/decisions/0018-host-capability-catalog.md
@@ -1,4 +1,4 @@
-# 17. Host capability catalog
+# 18. Host capability catalog
 
 Date: 2026-07-22
 

--- a/lib/host/clock.js
+++ b/lib/host/clock.js
@@ -1,0 +1,10 @@
+/**
+ * I am the host clock: the source of the current time. Isolating time behind a message
+ * send lets tests inject a deterministic clock (the test-double exception of decision
+ * 0005, since the clock is an external system we cannot control). See decision 0017.
+ */
+export class SystemClock {
+  now() {
+    return Date.now();
+  }
+}

--- a/lib/host/clock.js
+++ b/lib/host/clock.js
@@ -1,7 +1,7 @@
 /**
  * I am the host clock: the source of the current time. Isolating time behind a message
  * send lets tests inject a deterministic clock (the test-double exception of decision
- * 0005, since the clock is an external system we cannot control). See decision 0017.
+ * 0005, since the clock is an external system we cannot control). See decision 0018.
  */
 export class SystemClock {
   now() {

--- a/lib/ui/console_formatter.js
+++ b/lib/ui/console_formatter.js
@@ -18,8 +18,8 @@ export class ConsoleFormatter extends Formatter {
   #timerName;
   #filter;
 
-  constructor(console, i18n) {
-    super(console, i18n);
+  constructor(console, i18n, clock) {
+    super(console, i18n, clock);
     this.#timerName = this.translated('total_time');
   }
 

--- a/lib/ui/formatter.js
+++ b/lib/ui/formatter.js
@@ -1,4 +1,5 @@
 import { isString } from '../utils/index.js';
+import { SystemClock } from '../host/clock.js';
 
 /**
  * I am the base of the formatter family. I define the protocol of events that a
@@ -11,16 +12,22 @@ import { isString } from '../utils/index.js';
 export class Formatter {
   #console;
   #i18n;
+  #clock;
 
-  constructor(console, i18n) {
+  constructor(console, i18n, clock = new SystemClock()) {
     this.#console = console;
     this.#i18n = i18n;
+    this.#clock = clock;
   }
 
   // protected helpers for subclasses
 
   print(text) {
     this.#console.log(text);
+  }
+
+  currentTime() {
+    return this.#clock.now();
   }
 
   startConsoleTimer(name) {

--- a/lib/ui/formatter_factory.js
+++ b/lib/ui/formatter_factory.js
@@ -1,19 +1,20 @@
 import { ConsoleFormatter } from './console_formatter.js';
 import { TapFormatter } from './tap_formatter.js';
 import { JsonFormatter } from './json_formatter.js';
+import { SystemClock } from '../host/clock.js';
 
 /**
  * I build the right {@link Formatter} for a configured output format, defaulting to the
  * human-readable {@link ConsoleFormatter} when the format is unknown.
  */
 export class FormatterFactory {
-  static for(output, console, i18n) {
+  static for(output, console, i18n, clock = new SystemClock()) {
     const formatters = {
       console: ConsoleFormatter,
       tap: TapFormatter,
       json: JsonFormatter,
     };
     const FormatterClass = formatters[output] || ConsoleFormatter;
-    return new FormatterClass(console, i18n);
+    return new FormatterClass(console, i18n, clock);
   }
 }

--- a/lib/ui/json_formatter.js
+++ b/lib/ui/json_formatter.js
@@ -14,15 +14,15 @@ export class JsonFormatter extends Formatter {
   #currentSuite;
   #startTime;
 
-  constructor(console, i18n) {
-    super(console, i18n);
+  constructor(console, i18n, clock) {
+    super(console, i18n, clock);
     this.#suites = [];
     this.#currentSuite = undefined;
     this.#startTime = 0;
   }
 
   startTimer() {
-    this.#startTime = Date.now();
+    this.#startTime = this.currentTime();
   }
 
   displaySuiteStart(suite) {
@@ -61,7 +61,7 @@ export class JsonFormatter extends Formatter {
         errored: runner.errorsCount(),
         pending: runner.pendingCount(),
         skipped: runner.skippedCount(),
-        durationMs: Date.now() - this.#startTime,
+        durationMs: this.currentTime() - this.#startTime,
       },
       suites: this.#suites,
     };

--- a/lib/ui/tap_formatter.js
+++ b/lib/ui/tap_formatter.js
@@ -9,14 +9,14 @@ export class TapFormatter extends Formatter {
   #testNumber;
   #startTime;
 
-  constructor(console, i18n) {
-    super(console, i18n);
+  constructor(console, i18n, clock) {
+    super(console, i18n, clock);
     this.#testNumber = 0;
     this.#startTime = 0;
   }
 
   startTimer() {
-    this.#startTime = Date.now();
+    this.#startTime = this.currentTime();
   }
 
   displayInitialInformation(_configuration, _paths) {
@@ -49,7 +49,7 @@ export class TapFormatter extends Formatter {
     this.print(`# error ${runner.errorsCount()}`);
     this.print(`# pending ${runner.pendingCount()}`);
     this.print(`# skip ${runner.skippedCount()}`);
-    this.print(`# time ${Date.now() - this.#startTime}ms`);
+    this.print(`# time ${this.currentTime() - this.#startTime}ms`);
   }
 
   #printDiagnostic(test, severity) {

--- a/tests/host/clock_test.js
+++ b/tests/host/clock_test.js
@@ -1,0 +1,16 @@
+import { assert, suite, test } from '../../lib/testy.js';
+import { SystemClock } from '../../lib/host/clock.js';
+
+suite('system clock', () => {
+  test('answers a numeric instant in milliseconds', () => {
+    const instant = new SystemClock().now();
+    assert.that(typeof instant).isEqualTo('number');
+  });
+
+  test('never moves backwards between two reads', () => {
+    const clock = new SystemClock();
+    const first = clock.now();
+    const second = clock.now();
+    assert.that(second).isGreaterThanOrEqualTo(first);
+  });
+});

--- a/tests/host/clock_test.js
+++ b/tests/host/clock_test.js
@@ -28,4 +28,10 @@ suite('fake clock', () => {
     assert.that(clock.now()).isEqualTo(5);
     assert.that(clock.now()).isEqualTo(5);
   });
+
+  test('defaults to instant zero when created with no instants', () => {
+    const clock = FakeClock.startingAt();
+    assert.that(clock.now()).isEqualTo(0);
+    assert.that(clock.now()).isEqualTo(0);
+  });
 });

--- a/tests/host/clock_test.js
+++ b/tests/host/clock_test.js
@@ -1,5 +1,6 @@
 import { assert, suite, test } from '../../lib/testy.js';
 import { SystemClock } from '../../lib/host/clock.js';
+import { FakeClock } from '../support/fake_clock.js';
 
 suite('system clock', () => {
   test('answers a numeric instant in milliseconds', () => {
@@ -12,5 +13,19 @@ suite('system clock', () => {
     const first = clock.now();
     const second = clock.now();
     assert.that(second).isGreaterThanOrEqualTo(first);
+  });
+});
+
+suite('fake clock', () => {
+  test('answers programmed instants in order', () => {
+    const clock = FakeClock.startingAt(10, 25);
+    assert.that(clock.now()).isEqualTo(10);
+    assert.that(clock.now()).isEqualTo(25);
+  });
+
+  test('repeats the last instant once exhausted', () => {
+    const clock = FakeClock.startingAt(5);
+    assert.that(clock.now()).isEqualTo(5);
+    assert.that(clock.now()).isEqualTo(5);
   });
 });

--- a/tests/support/fake_clock.js
+++ b/tests/support/fake_clock.js
@@ -1,0 +1,26 @@
+/**
+ * A deterministic clock for tests. It answers the pre-programmed instants in order and
+ * repeats the last one once exhausted, so duration assertions become exact. It honours
+ * the same protocol as SystemClock (now()).
+ */
+export class FakeClock {
+  #instants;
+  #index;
+
+  static startingAt(...instants) {
+    return new this(instants);
+  }
+
+  constructor(instants) {
+    this.#instants = instants.length > 0 ? instants : [0];
+    this.#index = 0;
+  }
+
+  now() {
+    const { [this.#index]: instant } = this.#instants;
+    if (this.#index < this.#instants.length - 1) {
+      this.#index += 1;
+    }
+    return instant;
+  }
+}

--- a/tests/support/fake_clock.js
+++ b/tests/support/fake_clock.js
@@ -17,7 +17,7 @@ export class FakeClock {
   }
 
   now() {
-    const { [this.#index]: instant } = this.#instants;
+    const instant = this.#instants[this.#index];
     if (this.#index < this.#instants.length - 1) {
       this.#index += 1;
     }

--- a/tests/ui/json_formatter_test.js
+++ b/tests/ui/json_formatter_test.js
@@ -4,6 +4,7 @@ import { runResultsWith, driveFormatter } from '../support/formatter_helpers.js'
 import { JsonFormatter } from '../../lib/ui/json_formatter.js';
 import { I18n } from '../../lib/i18n/i18n.js';
 import { FakeConsole } from './fake_console.js';
+import { FakeClock } from '../support/fake_clock.js';
 
 suite('json formatter', () => {
   let formatter, fakeConsole;
@@ -12,7 +13,7 @@ suite('json formatter', () => {
 
   before(() => {
     fakeConsole = new FakeConsole();
-    formatter = new JsonFormatter(fakeConsole, I18n.default());
+    formatter = new JsonFormatter(fakeConsole, I18n.default(), FakeClock.startingAt(1000, 1350));
   });
 
   test('emits exactly one JSON document', async() => {
@@ -40,7 +41,7 @@ suite('json formatter', () => {
     assert.that(summary.errored).isEqualTo(1);
     assert.that(summary.pending).isEqualTo(1);
     assert.that(summary.skipped).isEqualTo(1);
-    assert.that(summary.durationMs).isGreaterThanOrEqualTo(0);
+    assert.that(summary.durationMs).isEqualTo(350);
   });
 
   test('records each test name, status, and the suite file', async() => {

--- a/tests/ui/tap_formatter_test.js
+++ b/tests/ui/tap_formatter_test.js
@@ -4,13 +4,14 @@ import { runResultsWith, driveFormatter } from '../support/formatter_helpers.js'
 import { TapFormatter } from '../../lib/ui/tap_formatter.js';
 import { I18n } from '../../lib/i18n/i18n.js';
 import { FakeConsole } from './fake_console.js';
+import { FakeClock } from '../support/fake_clock.js';
 
 suite('tap formatter', () => {
   let formatter, fakeConsole;
 
   before(() => {
     fakeConsole = new FakeConsole();
-    formatter = new TapFormatter(fakeConsole, I18n.default());
+    formatter = new TapFormatter(fakeConsole, I18n.default(), FakeClock.startingAt(1000, 1350));
   });
 
   test('emits the TAP version header on initial information', () => {
@@ -57,5 +58,11 @@ suite('tap formatter', () => {
     assert.that(messages).includes('not ok 1 - an unexpected error');
     assert.that(messages).includes('  severity: error');
     assert.that(messages).includes('# error 1');
+  });
+
+  test('reports the elapsed time from the injected clock', async() => {
+    const { runner, suite: ranSuite } = await runResultsWith('s', aPassingTest);
+    driveFormatter(formatter, runner, ranSuite);
+    assert.that(fakeConsole.messages()).includes('# time 350ms');
   });
 });


### PR DESCRIPTION
## What

Starts decoupling Testy's core from Node internals, following the strategy recorded in **ADR 0018 — Host capability catalog** (`doc/decisions/0018-host-capability-catalog.md`).

> Note: this ADR was originally authored as 0017 but renumbered to **0018** after rebasing, since `0017-simplicity-guardian` landed on `main` first.

This PR lays the foundation and lands the first host-service role:

### ADR 0018 — Host capability catalog
Names the capabilities Testy needs from its host as an explicit, named contract (the portability seam), classified into **host services** (I/O, runtime-dependent, injectable) and **reimplementable semantics** (algorithms rewritten per language).

### Phase 1 — Clock role
- New `lib/host/clock.js` (`SystemClock.now()` → `Date.now()`), the first host-service role object.
- New `tests/support/fake_clock.js` (`FakeClock`), a deterministic test double — the sanctioned external-system double of ADR 0005.
- The formatter family now takes an injected `clock` (default `new SystemClock()`) and reads time via a protected `currentTime()` helper.
- `Date.now()` no longer appears anywhere in `lib/ui/`.

## Why
The valuable artifact for a future language port is knowing *what Testy needs from its host*, named in domain terms — not a wrapper over `fs`/`Date`. This is the first concrete step. Injecting the clock also makes timing assertions deterministic (e.g. the TAP `# time` line and JSON `durationMs` are now asserted exactly at `350ms`, instead of the previous weak `>= 0`).

## Testing
- Full self-test suite green: **452/452** (after rebase onto latest `main`).
- `npm run lint` clean (project config).

## Notes
Follow-up phases (FileSystem, TestLoader, JSON/config reading) are planned as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)