### PR TITLE
Fix Simplicity Guardian fan-out violation in lib/testy.js

### DIFF
--- a/lib/core/test_file_loader.js
+++ b/lib/core/test_file_loader.js
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import pathUtils from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { allFilesMatching, resolvePathFor, errorDetailOf } from '../utils/index.js';
+import { I18nMessage } from '../i18n/i18n_messages.js';
+import { TypescriptTranspiler } from '../typescript/typescript_transpiler.js';
+
+/**
+ * I discover, transpile (when needed), load and clean up the test files matching a
+ * given set of paths and a filter. I am injected with `ui` and `testRunner` so I can
+ * report progress and errors the same way `Testy` does. Extracting me out of `Testy`
+ * keeps `lib/testy.js`'s import count under the Simplicity Guardian's fan-out
+ * threshold (see decision 0017).
+ */
+export class TestFileLoader {
+  #ui;
+  #testRunner;
+
+  constructor(ui, testRunner) {
+    this.#ui = ui;
+    this.#testRunner = testRunner;
+  }
+
+  async loadAll(requestedPaths, filterRegex) {
+    try {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const path of this.#resolvedPathsFor(requestedPaths)) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.#loadAllFilesIn(path, filterRegex);
+      }
+    } catch (err) {
+      this.#ui.exitWithError(I18nMessage.of('error_path_not_found', err.path));
+    }
+  }
+
+  // private
+
+  #resolvedPathsFor(paths) {
+    return paths.map(path => resolvePathFor(path));
+  }
+
+  async #loadAllFilesIn(path, filterRegex) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const file of allFilesMatching(path, filterRegex)) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.#loadFileHandlingErrors(file);
+    }
+  }
+
+  // eslint-disable-next-line max-statements
+  async #loadFileHandlingErrors(filePath) {
+    let importPath = filePath;
+    let isTempFileCreated = false;
+
+    try {
+      this.#testRunner.loadingFile(filePath);
+      const fileExtension = pathUtils.extname(filePath);
+
+      if (fileExtension === '.ts') {
+        const transpilationResult = await TypescriptTranspiler.generateTemporalJavascriptFromTypescript(filePath);
+        ({ importPath, isTempFileCreated } = transpilationResult);
+      }
+
+      const fileUrl = pathToFileURL(importPath);
+      await import(fileUrl);
+    } catch (err) {
+      this.#ui.exitWithError(
+        I18nMessage.of('error_loading_suite', filePath), errorDetailOf(err),
+        I18nMessage.of('feedback_for_error_loading_suite'),
+      );
+    } finally {
+      this.#cleanupTemporaryFile(isTempFileCreated, importPath);
+    }
+  }
+
+  #cleanupTemporaryFile(shouldRemoveFile, path) {
+    if (shouldRemoveFile && path && fs.existsSync(path)) {
+      try {
+        fs.unlinkSync(path);
+      } catch (cleanupError) {
+        this.#ui.exitWithError(
+          I18nMessage.of('error_deleting_temporary_file', path), errorDetailOf(cleanupError),
+        );
+      }
+    }
+  }
+}

--- a/lib/dsl.js
+++ b/lib/dsl.js
@@ -1,0 +1,120 @@
+import process from 'node:process';
+import console from 'node:console';
+import { TestRunner } from './core/test_runner.js';
+import { Asserter, FailureGenerator, PendingMarker } from './core/asserter.js';
+import { ConsoleUI } from './ui/console_ui.js';
+
+const ui = new ConsoleUI(process, console);
+const testRunner = new TestRunner(ui.testRunnerCallbacks());
+
+/**
+ * Object used for writing assertions. [Assertions]{@link Assertion} are created with method calls to this object.
+ * Please refer to the comment of each assertion for more information.
+ *
+ * @example
+ * assert.isFalse(3 > 4)
+ * @example
+ * assert.that(['hey']).isNotEmpty()
+ *
+ * @type {Asserter}
+ */
+const assert = new Asserter(testRunner);
+
+/**
+ * Generates an explicit failure.
+ *
+ * @example
+ * fail.with('a descriptive message')
+ *
+ * @type {FailureGenerator}
+ */
+const fail = new FailureGenerator(testRunner);
+
+/**
+ * Marks a test as pending, which is a status that is reported separately, and it's not considered success/failure.
+ * It is useful to mark in-progress work and catch the developers attention in the resulting report.
+ *
+ * @example
+ * pending.dueTo('finish the set-up process')
+ *
+ * @type {PendingMarker}
+ */
+const pending = new PendingMarker(testRunner);
+
+/**
+ * Defines a new test. Each test belongs to a [test suite]{@link suite} and defines assertions in the body.
+ *
+ * For info about assertions, take a look at the {@link assert} object.
+ *
+ * Tests are represented internally as instances of {@link Test}.
+ *
+ * @example
+ * test('arithmetic works', () => {
+ *   assert.areEqual(3 + 4, 7);
+ * });
+ *
+ * @param {!string} name how you would like to call the test. Non-empty string.
+ * @param {!function} testBody the test definition, written as a zero-argument function.
+ * @returns {void}
+ */
+function test(name, testBody) {
+  return testRunner.registerTest(name, testBody, ui.testCallbacks());
+}
+
+/**
+ * Defines a new test suite. Suites are expected to define [tests]{@link test} inside it.
+ * There can be more than one suite per file, but it is not possible to nest suites.
+ *
+ * @example
+ * suite('arithmetic operations', () => {
+ *   test('the sum of two number works', () => {
+ *     assert.areEqual(3 + 4, 7);
+ *   });
+ * });
+ *
+ * @param {!string} name how you would like to call the suite. Non-empty string.
+ * @param {!function} suiteBody the suite definition, written as a zero-argument function.
+ * @returns {void}
+ */
+function suite(name, suiteBody) {
+  return testRunner.registerSuite(name, suiteBody, ui.suiteCallbacks());
+}
+
+/**
+ * Specifies a piece of code that should be executed before each {@link test} in a {@link suite}.
+ * Only one before block is allowed per suite. The most common use of this feature is to initialize objects you want
+ * to reference in each test.
+ *
+ * @example
+ * suite('using a before() initializer', () => {
+ *   let number;
+ *
+ *   before(() => {
+ *     number = 42;
+ *   });
+ *
+ *   test('has the initialized value', () => {
+ *     assert.that(number).isEqualTo(42);
+ *   });
+ * });
+ *
+ * @param {!function} initialization a zero argument function containing the code you want to execute before each test.
+ * @returns {void}
+ */
+function before(initialization) {
+  testRunner.registerBefore(initialization);
+}
+
+/**
+ * Specifies a piece of code that should be executed after each {@link test} in a {@link suite}.
+ * Only one after block is allowed per suite. The most common use of this feature is to ensure you are releasing
+ * resources that are used on each test, like files.
+ *
+ * @param {!function} releaseBlock a zero argument function containing the code you want to execute after each test.
+ * @returns {void}
+ */
+function after(releaseBlock) {
+  testRunner.registerAfter(releaseBlock);
+}
+
+export { ui, testRunner, assert, fail, pending, test, suite, before, after };

--- a/lib/testy.js
+++ b/lib/testy.js
@@ -1,132 +1,14 @@
-/*eslint max-statements: 'off'*/
-import process from 'node:process';
-import console from 'node:console';
-import { TestRunner } from './core/test_runner.js';
-import { Asserter, FailureGenerator, PendingMarker } from './core/asserter.js';
-import { ConsoleUI } from './ui/console_ui.js';
-import { allFilesMatching, errorDetailOf, resolvePathFor } from './utils/index.js';
+import { errorDetailOf } from './utils/index.js';
 import { I18nMessage } from './i18n/i18n_messages.js';
-import fs from 'node:fs';
-import pathUtils from 'node:path';
-import { pathToFileURL } from 'node:url';
-import { TypescriptTranspiler } from './typescript/typescript_transpiler.js';
+import { TestFileLoader } from './core/test_file_loader.js';
+import { ui, testRunner } from './dsl.js';
 
-const ui = new ConsoleUI(process, console);
-const testRunner = new TestRunner(ui.testRunnerCallbacks());
-
-/**
- * Object used for writing assertions. [Assertions]{@link Assertion} are created with method calls to this object.
- * Please refer to the comment of each assertion for more information.
- *
- * @example
- * assert.isFalse(3 > 4)
- * @example
- * assert.that(['hey']).isNotEmpty()
- *
- * @type {Asserter}
- */
-const assert = new Asserter(testRunner);
-
-/**
- * Generates an explicit failure.
- *
- * @example
- * fail.with('a descriptive message')
- *
- * @type {FailureGenerator}
- */
-const fail = new FailureGenerator(testRunner);
-
-/**
- * Marks a test as pending, which is a status that is reported separately, and it's not considered success/failure.
- * It is useful to mark in-progress work and catch the developers attention in the resulting report.
- *
- * @example
- * pending.dueTo('finish the set-up process')
- *
- * @type {PendingMarker}
- */
-const pending = new PendingMarker(testRunner);
-
-/**
- * Defines a new test. Each test belongs to a [test suite]{@link suite} and defines assertions in the body.
- *
- * For info about assertions, take a look at the {@link assert} object.
- *
- * Tests are represented internally as instances of {@link Test}.
- *
- * @example
- * test('arithmetic works', () => {
- *   assert.areEqual(3 + 4, 7);
- * });
- *
- * @param {!string} name how you would like to call the test. Non-empty string.
- * @param {!function} testBody the test definition, written as a zero-argument function.
- * @returns {void}
- */
-function test(name, testBody) {
-  return testRunner.registerTest(name, testBody, ui.testCallbacks());
-}
-
-/**
- * Defines a new test suite. Suites are expected to define [tests]{@link test} inside it.
- * There can be more than one suite per file, but it is not possible to nest suites.
- *
- * @example
- * suite('arithmetic operations', () => {
- *   test('the sum of two number works', () => {
- *     assert.areEqual(3 + 4, 7);
- *   });
- * });
- *
- * @param {!string} name how you would like to call the suite. Non-empty string.
- * @param {!function} suiteBody the suite definition, written as a zero-argument function.
- * @returns {void}
- */
-function suite(name, suiteBody) {
-  return testRunner.registerSuite(name, suiteBody, ui.suiteCallbacks());
-}
-
-/**
- * Specifies a piece of code that should be executed before each {@link test} in a {@link suite}.
- * Only one before block is allowed per suite. The most common use of this feature is to initialize objects you want
- * to reference in each test.
- *
- * @example
- * suite('using a before() initializer', () => {
- *   let number;
- *
- *   before(() => {
- *     number = 42;
- *   });
- *
- *   test('has the initialized value', () => {
- *     assert.that(number).isEqualTo(42);
- *   });
- * });
- *
- * @param {!function} initialization a zero argument function containing the code you want to execute before each test.
- * @returns {void}
- */
-function before(initialization) {
-  testRunner.registerBefore(initialization);
-}
-
-/**
- * Specifies a piece of code that should be executed after each {@link test} in a {@link suite}.
- * Only one after block is allowed per suite. The most common use of this feature is to ensure you are releasing
- * resources that are used on each test, like files.
- *
- * @param {!function} releaseBlock a zero argument function containing the code you want to execute after each test.
- * @returns {void}
- */
-function after(releaseBlock) {
-  testRunner.registerAfter(releaseBlock);
-}
+export { test, suite, before, after, assert, fail, pending } from './dsl.js';
 
 class Testy {
   #configuration;
   #requestedPaths;
+  #fileLoader;
 
   // instance creation
 
@@ -135,6 +17,7 @@ class Testy {
   }
 
   constructor(configuration) {
+    this.#fileLoader = new TestFileLoader(ui, testRunner);
     this.#initializeConfiguredWith(configuration);
   }
 
@@ -142,8 +25,9 @@ class Testy {
 
   async run(requestedPaths) {
     this.#requestedPaths = requestedPaths;
-    await this.#loadAllRequestedFiles();
-    ui.start(this.#configuration, this.#testFilesPathsToRun());
+    const pathsToRun = this.#testFilesPathsToRun();
+    await this.#fileLoader.loadAll(pathsToRun, this.#configuration.filter());
+    ui.start(this.#configuration, pathsToRun);
     try {
       await testRunner.run();
     } catch (err) {
@@ -161,79 +45,14 @@ class Testy {
 
   // private
 
-  async #loadAllRequestedFiles() {
-    try {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const path of this.#resolvedTestFilesPathsToRun()) {
-        // eslint-disable-next-line no-await-in-loop
-        await this.#loadAllFilesIn(path);
-      }
-    } catch (err) {
-      ui.exitWithError(I18nMessage.of('error_path_not_found', err.path));
-    }
-  }
-
-  async #loadAllFilesIn(path) {
-    // eslint-disable-next-line no-restricted-syntax
-    for (const file of allFilesMatching(path, this.#testFilesFilter())) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.#loadFileHandlingErrors(file);
-    }
-  }
-
-  async #loadFileHandlingErrors(filePath) {
-    let importPath = filePath;
-    let isTempFileCreated = false;
-
-    try {
-      testRunner.loadingFile(filePath);
-      const fileExtension = pathUtils.extname(filePath);
-
-      if (fileExtension === '.ts') {
-        const transpilationResult = await TypescriptTranspiler.generateTemporalJavascriptFromTypescript(filePath);
-        ({ importPath, isTempFileCreated } = transpilationResult);
-      }
-
-      const fileUrl = pathToFileURL(importPath);
-      await import(fileUrl);
-    } catch (err) {
-      ui.exitWithError(
-        I18nMessage.of('error_loading_suite', filePath), errorDetailOf(err),
-        I18nMessage.of('feedback_for_error_loading_suite'),
-      );
-    } finally {
-      this.#cleanupTemporaryFile(isTempFileCreated, importPath);
-    }
-  }
-
-  #cleanupTemporaryFile(shouldRemoveFile, path) {
-    if (shouldRemoveFile && path && fs.existsSync(path)) {
-      try {
-        fs.unlinkSync(path);
-      } catch (cleanupError) {
-        ui.exitWithError(
-          I18nMessage.of('error_deleting_temporary_file', path), errorDetailOf(cleanupError),
-        );
-      }
-    }
-  }
-
   #testFilesPathsToRun() {
     const requestedPaths = this.#requestedPaths;
     return requestedPaths.length > 0 ? requestedPaths : [this.#pathForAllTests()];
   }
 
-  #resolvedTestFilesPathsToRun() {
-    return this.#testFilesPathsToRun().map(path => resolvePathFor(path));
-  }
-
   #pathForAllTests() {
     return this.#configuration.directory();
   }
-
-  #testFilesFilter() {
-    return this.#configuration.filter();
-  }
 }
 
-export { Testy, suite, test, assert, fail, pending, before, after };
+export { Testy };

--- a/tests/core/fixtures/loader_fixture_ok.js
+++ b/tests/core/fixtures/loader_fixture_ok.js
@@ -1,0 +1,2 @@
+// Fixture used by test_file_loader_test.js: a valid module that loads without error.
+export const loadedMarker = 'loader-fixture-ok';

--- a/tests/core/fixtures/loader_fixture_throws.js
+++ b/tests/core/fixtures/loader_fixture_throws.js
@@ -1,0 +1,3 @@
+// Fixture used by test_file_loader_test.js: throws when imported, to exercise the
+// "error loading suite" path.
+throw new Error('boom from fixture');

--- a/tests/core/test_file_loader_test.js
+++ b/tests/core/test_file_loader_test.js
@@ -1,0 +1,48 @@
+import { assert, suite, test, before } from '../../lib/testy.js';
+import { TestFileLoader } from '../../lib/core/test_file_loader.js';
+import { ConsoleUI } from '../../lib/ui/console_ui.js';
+import { FakeProcess } from '../ui/fake_process.js';
+import { FakeConsole } from '../ui/fake_console.js';
+import { withRunner } from '../support/runner_helpers.js';
+
+const fixturesDir = 'tests/core/fixtures';
+
+suite('TestFileLoader', () => {
+  let fakeProcess, fakeConsole, ui;
+
+  before(() => {
+    fakeProcess = new FakeProcess();
+    fakeConsole = new FakeConsole();
+    ui = new ConsoleUI(fakeProcess, fakeConsole);
+  });
+
+  test('loads every file matching the filter under the given path without reporting errors', async() => {
+    await withRunner(async runner => {
+      const loader = new TestFileLoader(ui, runner);
+
+      await loader.loadAll([fixturesDir], /loader_fixture_ok\.js$/u);
+
+      assert.that(fakeProcess.lastExitCode()).isNull();
+    });
+  });
+
+  test('reports an error and exits when the requested path does not exist', async() => {
+    await withRunner(async runner => {
+      const loader = new TestFileLoader(ui, runner);
+
+      await loader.loadAll(['tests/core/fixtures/does-not-exist'], /.*/u);
+
+      assert.that(fakeProcess.lastExitCode()).isEqualTo(ConsoleUI.failedExitCode());
+    });
+  });
+
+  test('reports an error and exits when a matched file throws on import', async() => {
+    await withRunner(async runner => {
+      const loader = new TestFileLoader(ui, runner);
+
+      await loader.loadAll([fixturesDir], /loader_fixture_throws\.js$/u);
+
+      assert.that(fakeProcess.lastExitCode()).isEqualTo(ConsoleUI.failedExitCode());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/testy.js` had 11 import lines, over the Simplicity Guardian's fan-out threshold of 7 (pre-existing on `main`, unrelated to `host-capability-catalog`).
- Split it into three single-responsibility modules, with no behavior change:
  - `lib/dsl.js` — the public test-writing DSL (`assert`, `fail`, `pending`, `test`, `suite`, `before`, `after`) plus the `ui`/`testRunner` singletons, relocated verbatim.
  - `lib/core/test_file_loader.js` — new `TestFileLoader` class (constructor-injected with `ui`/`testRunner`, same style as `ConsoleUI(process, console)`) owning file discovery, TypeScript transpilation, dynamic import, and temp-file cleanup. Includes its own test file and fixtures.
  - `lib/testy.js` — now a thin orchestrator: re-exports the DSL from `dsl.js` and delegates loading to `TestFileLoader`. Down to 4 import lines.
- No consumer changes needed — every test file and `lib/script_action.js` keep importing the same names from the same path.

## Test plan
- [x] `npm test` — 446/446 passing (443 original + 3 new for `TestFileLoader`)
- [x] `npm run lint` — clean
- [x] `node bin/simplicity-guardian.js` — zero violations
- [x] Import counts verified: `lib/testy.js` 4, `lib/dsl.js` 5, `lib/core/test_file_loader.js` 6 (all ≤ 7)