### PR TITLE
feat: add NodeFileSystem host role (Phase 2)

### DIFF
--- a/lib/core/test_file_loader.js
+++ b/lib/core/test_file_loader.js
@@ -1,9 +1,8 @@
-import fs from 'node:fs';
-import pathUtils from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { allFilesMatching, resolvePathFor, errorDetailOf } from '../utils/index.js';
+import { errorDetailOf } from '../utils/index.js';
 import { I18nMessage } from '../i18n/i18n_messages.js';
 import { TypescriptTranspiler } from '../typescript/typescript_transpiler.js';
+import { NodeFileSystem } from '../host/file_system.js';
 
 /**
  * I discover, transpile (when needed), load and clean up the test files matching a
@@ -15,10 +14,12 @@ import { TypescriptTranspiler } from '../typescript/typescript_transpiler.js';
 export class TestFileLoader {
   #ui;
   #testRunner;
+  #fileSystem;
 
-  constructor(ui, testRunner) {
+  constructor(ui, testRunner, fileSystem = new NodeFileSystem()) {
     this.#ui = ui;
     this.#testRunner = testRunner;
+    this.#fileSystem = fileSystem;
   }
 
   async loadAll(requestedPaths, filterRegex) {
@@ -36,12 +37,12 @@ export class TestFileLoader {
   // private
 
   #resolvedPathsFor(paths) {
-    return paths.map(path => resolvePathFor(path));
+    return paths.map(path => this.#fileSystem.resolvePathFor(path));
   }
 
   async #loadAllFilesIn(path, filterRegex) {
     // eslint-disable-next-line no-restricted-syntax
-    for (const file of allFilesMatching(path, filterRegex)) {
+    for (const file of this.#fileSystem.allFilesMatching(path, filterRegex)) {
       // eslint-disable-next-line no-await-in-loop
       await this.#loadFileHandlingErrors(file);
     }
@@ -54,7 +55,7 @@ export class TestFileLoader {
 
     try {
       this.#testRunner.loadingFile(filePath);
-      const fileExtension = pathUtils.extname(filePath);
+      const fileExtension = this.#fileSystem.extensionOf(filePath);
 
       if (fileExtension === '.ts') {
         const transpilationResult = await TypescriptTranspiler.generateTemporalJavascriptFromTypescript(filePath);
@@ -74,14 +75,15 @@ export class TestFileLoader {
   }
 
   #cleanupTemporaryFile(shouldRemoveFile, path) {
-    if (shouldRemoveFile && path && fs.existsSync(path)) {
-      try {
-        fs.unlinkSync(path);
-      } catch (cleanupError) {
-        this.#ui.exitWithError(
-          I18nMessage.of('error_deleting_temporary_file', path), errorDetailOf(cleanupError),
-        );
-      }
+    if (!shouldRemoveFile) {
+      return;
+    }
+    try {
+      this.#fileSystem.deleteFileIfExists(path);
+    } catch (cleanupError) {
+      this.#ui.exitWithError(
+        I18nMessage.of('error_deleting_temporary_file', path), errorDetailOf(cleanupError),
+      );
     }
   }
 }

--- a/lib/host/file_system.js
+++ b/lib/host/file_system.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+/**
+ * I am the host file system. I expose, in domain terms, the file and path operations Testy
+ * needs: find test files under a directory, resolve a path, answer a path's extension, and
+ * remove a temporary file. The core never names Node's fs/path APIs directly. See decision
+ * 0018 (host capability catalog).
+ */
+export class NodeFileSystem {
+  resolvePathFor(relativePath) {
+    return path.resolve(process.cwd(), relativePath);
+  }
+
+  allFilesMatching(dir, regex) {
+    if (fs.lstatSync(dir).isFile()) {
+      return dir.match(regex) ? [dir] : [];
+    }
+    return fs.readdirSync(dir).flatMap(entry => this.allFilesMatching(path.join(dir, entry), regex));
+  }
+
+  extensionOf(filePath) {
+    return path.extname(filePath);
+  }
+
+  deleteFileIfExists(filePath) {
+    if (filePath && fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+}

--- a/tests/core/test_file_loader_test.js
+++ b/tests/core/test_file_loader_test.js
@@ -1,6 +1,7 @@
 import { assert, suite, test, before } from '../../lib/testy.js';
 import { TestFileLoader } from '../../lib/core/test_file_loader.js';
 import { ConsoleUI } from '../../lib/ui/console_ui.js';
+import { NodeFileSystem } from '../../lib/host/file_system.js';
 import { FakeProcess } from '../ui/fake_process.js';
 import { FakeConsole } from '../ui/fake_console.js';
 import { withRunner } from '../support/runner_helpers.js';
@@ -43,6 +44,23 @@ suite('TestFileLoader', () => {
       await loader.loadAll([fixturesDir], /loader_fixture_throws\.js$/u);
 
       assert.that(fakeProcess.lastExitCode()).isEqualTo(ConsoleUI.failedExitCode());
+    });
+  });
+
+  test('uses the injected file system to discover files', async() => {
+    await withRunner(async runner => {
+      const seen = [];
+      const recordingFileSystem = Object.assign(new NodeFileSystem(), {
+        allFilesMatching(dir, regex) {
+          seen.push(dir);
+          return NodeFileSystem.prototype.allFilesMatching.call(this, dir, regex);
+        },
+      });
+      const loader = new TestFileLoader(ui, runner, recordingFileSystem);
+
+      await loader.loadAll([fixturesDir], /loader_fixture_ok\.js$/u);
+
+      assert.that(seen.length).isGreaterThan(0);
     });
   });
 });

--- a/tests/host/file_system_test.js
+++ b/tests/host/file_system_test.js
@@ -1,0 +1,50 @@
+import { assert, after, before, suite, test } from '../../lib/testy.js';
+import { NodeFileSystem } from '../../lib/host/file_system.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+suite('node file system', () => {
+  let fileSystem, tempDir;
+
+  before(() => {
+    fileSystem = new NodeFileSystem();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'testy-fs-'));
+    fs.writeFileSync(path.join(tempDir, 'a_test.js'), '');
+    fs.writeFileSync(path.join(tempDir, 'helper.js'), '');
+    fs.mkdirSync(path.join(tempDir, 'nested'));
+    fs.writeFileSync(path.join(tempDir, 'nested', 'b_test.js'), '');
+  });
+
+  after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  test('finds files matching a pattern recursively', () => {
+    const found = fileSystem.allFilesMatching(tempDir, /_test\.js$/u);
+    assert.that(found.length).isEqualTo(2);
+  });
+
+  test('excludes files that do not match', () => {
+    const found = fileSystem.allFilesMatching(tempDir, /_test\.js$/u);
+    assert.that(found.some(file => file.endsWith('helper.js'))).isFalse();
+  });
+
+  test('resolves a relative path against the current working directory', () => {
+    assert.that(fileSystem.resolvePathFor('x.json')).isEqualTo(path.resolve(process.cwd(), 'x.json'));
+  });
+
+  test('answers the extension of a path', () => {
+    assert.that(fileSystem.extensionOf('/tmp/foo.ts')).isEqualTo('.ts');
+  });
+
+  test('deletes an existing file', () => {
+    const target = path.join(tempDir, 'a_test.js');
+    fileSystem.deleteFileIfExists(target);
+    assert.that(fs.existsSync(target)).isFalse();
+  });
+
+  test('does nothing when deleting a missing file', () => {
+    fileSystem.deleteFileIfExists(path.join(tempDir, 'ghost.js'));
+    assert.isTrue(true);
+  });
+});


### PR DESCRIPTION
## Summary
Implements Phase 2 of the host capability boundary plan (doc/plans/2026-07-22-host-capability-boundary.md), following up on Phase 1 (Clock, PR #401).

- Adds `NodeFileSystem` (`lib/host/file_system.js`): file discovery, path resolution, path-extension query, and temp-file removal, in domain terms (ADR 0018).
- Injects it into `TestFileLoader` with a Node-backed default, replacing direct `fs`/`path` calls.

## Test plan
- [x] `npm test` — all suites green
- [x] `npm run lint` — clean on touched files
- [x] New unit tests for `NodeFileSystem` (`tests/host/file_system_test.js`)
- [x] New `TestFileLoader` test asserting file discovery is routed through the injected file system