### PR TITLE
feat: add NodeModuleLoader host role (Phase 3)

### DIFF
--- a/lib/core/test_file_loader.js
+++ b/lib/core/test_file_loader.js
@@ -1,8 +1,8 @@
-import { pathToFileURL } from 'node:url';
 import { errorDetailOf } from '../utils/index.js';
 import { I18nMessage } from '../i18n/i18n_messages.js';
 import { TypescriptTranspiler } from '../typescript/typescript_transpiler.js';
 import { NodeFileSystem } from '../host/file_system.js';
+import { NodeModuleLoader } from '../host/module_loader.js';
 
 /**
  * I discover, transpile (when needed), load and clean up the test files matching a
@@ -15,11 +15,13 @@ export class TestFileLoader {
   #ui;
   #testRunner;
   #fileSystem;
+  #moduleLoader;
 
-  constructor(ui, testRunner, fileSystem = new NodeFileSystem()) {
+  constructor(ui, testRunner, fileSystem = new NodeFileSystem(), moduleLoader = new NodeModuleLoader()) {
     this.#ui = ui;
     this.#testRunner = testRunner;
     this.#fileSystem = fileSystem;
+    this.#moduleLoader = moduleLoader;
   }
 
   async loadAll(requestedPaths, filterRegex) {
@@ -62,8 +64,7 @@ export class TestFileLoader {
         ({ importPath, isTempFileCreated } = transpilationResult);
       }
 
-      const fileUrl = pathToFileURL(importPath);
-      await import(fileUrl);
+      await this.#moduleLoader.load(importPath);
     } catch (err) {
       this.#ui.exitWithError(
         I18nMessage.of('error_loading_suite', filePath), errorDetailOf(err),

--- a/lib/host/module_loader.js
+++ b/lib/host/module_loader.js
@@ -1,0 +1,13 @@
+import { pathToFileURL } from 'node:url';
+
+/**
+ * I load and evaluate a JavaScript module given its file path. I isolate the Node-specific
+ * module-loading mechanism (dynamic import + file URL) — the least portable host capability
+ * of decision 0018. A port must provide its own equivalent. I am distinct from the domain
+ * orchestrator TestFileLoader, which discovers, transpiles, reports and cleans up.
+ */
+export class NodeModuleLoader {
+  async load(filePath) {
+    await import(pathToFileURL(filePath));
+  }
+}

--- a/tests/core/test_file_loader_test.js
+++ b/tests/core/test_file_loader_test.js
@@ -2,6 +2,7 @@ import { assert, suite, test, before } from '../../lib/testy.js';
 import { TestFileLoader } from '../../lib/core/test_file_loader.js';
 import { ConsoleUI } from '../../lib/ui/console_ui.js';
 import { NodeFileSystem } from '../../lib/host/file_system.js';
+import { NodeModuleLoader } from '../../lib/host/module_loader.js';
 import { FakeProcess } from '../ui/fake_process.js';
 import { FakeConsole } from '../ui/fake_console.js';
 import { withRunner } from '../support/runner_helpers.js';
@@ -57,6 +58,23 @@ suite('TestFileLoader', () => {
         },
       });
       const loader = new TestFileLoader(ui, runner, recordingFileSystem);
+
+      await loader.loadAll([fixturesDir], /loader_fixture_ok\.js$/u);
+
+      assert.that(seen.length).isGreaterThan(0);
+    });
+  });
+
+  test('uses the injected module loader to evaluate matched files', async() => {
+    await withRunner(async runner => {
+      const seen = [];
+      const recordingModuleLoader = Object.assign(new NodeModuleLoader(), {
+        load(filePath) {
+          seen.push(filePath);
+          return NodeModuleLoader.prototype.load.call(this, filePath);
+        },
+      });
+      const loader = new TestFileLoader(ui, runner, new NodeFileSystem(), recordingModuleLoader);
 
       await loader.loadAll([fixturesDir], /loader_fixture_ok\.js$/u);
 

--- a/tests/host/module_loader_test.js
+++ b/tests/host/module_loader_test.js
@@ -1,0 +1,35 @@
+import { assert, after, before, fail, suite, test } from '../../lib/testy.js';
+import { NodeModuleLoader } from '../../lib/host/module_loader.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+suite('node module loader', () => {
+  let loader, tempDir;
+
+  before(() => {
+    loader = new NodeModuleLoader();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'testy-loader-'));
+  });
+
+  after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  test('evaluates the module at the given path', async() => {
+    const marker = path.join(tempDir, 'marker.js');
+    const flag = path.join(tempDir, 'loaded.txt');
+    fs.writeFileSync(marker, `import fs from 'node:fs'; fs.writeFileSync(${JSON.stringify(flag)}, 'yes');`);
+    await loader.load(marker);
+    assert.that(fs.readFileSync(flag, 'utf8')).isEqualTo('yes');
+  });
+
+  test('propagates errors from a broken module', async() => {
+    const broken = path.join(tempDir, 'broken.js');
+    fs.writeFileSync(broken, 'throw new Error("boom");');
+    try {
+      await loader.load(broken);
+      fail.with('expected load to reject');
+    } catch (error) {
+      assert.that(error.message).isEqualTo('boom');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Implements Phase 3 of the host capability boundary plan (doc/plans/2026-07-22-host-capability-boundary.md). Stacked on #404 (Phase 2 — FileSystem); merge that one first.

- Adds `NodeModuleLoader` (`lib/host/module_loader.js`): isolates the Node-specific module-loading mechanism (dynamic `import()` + `pathToFileURL`) — the least portable host capability of ADR 0018.
- Injects it into `TestFileLoader` with a Node-backed default, replacing the direct `import()`/`pathToFileURL` calls.
- After this PR, `lib/core/test_file_loader.js` no longer imports `fs`, `path`, or `url` from Node — the only remaining host-specific dependency is `TypescriptTranspiler`, explicitly out of scope (a host-specific extension, not part of the portable core).

## Test plan
- [x] `npm test` — all suites green
- [x] `npm run lint` — clean on touched files
- [x] New unit tests for `NodeModuleLoader` (`tests/host/module_loader_test.js`)
- [x] New `TestFileLoader` test asserting module evaluation is routed through the injected module loader