### PR TITLE
docs: mark deepStrictEqual and prettyPrint as reimplementable-semantics seams

### DIFF
--- a/lib/utils/comparison.js
+++ b/lib/utils/comparison.js
@@ -20,6 +20,11 @@ const isCyclic = object => {
   return detect(object);
 };
 
+/**
+ * Reimplementable-semantics seam (ADR 0018): structural deep equality. A port targeting
+ * another language reimplements this comparison natively rather than depending on Node's
+ * `util.isDeepStrictEqual`.
+ */
 const deepStrictEqual = (objectOne, objectTwo) =>
   util.isDeepStrictEqual(objectOne, objectTwo);
 

--- a/lib/utils/formatting.js
+++ b/lib/utils/formatting.js
@@ -1,6 +1,11 @@
 import util from 'node:util';
 import { notNullOrUndefined } from './types.js';
 
+/**
+ * Reimplementable-semantics seam (ADR 0018): object inspection for failure messages. A port
+ * targeting another language reimplements this formatting natively rather than depending on
+ * Node's `util.inspect`.
+ */
 const prettyPrint = object => {
   const excludedToStrings = [Object.prototype.toString, String.prototype.toString, Array.prototype.toString];
   const shouldUseToStringMethod = notNullOrUndefined(object) && !excludedToStrings.includes(object.toString);


### PR DESCRIPTION
## Summary
Implements Phase 5 (doc-only) of the host capability boundary plan (doc/plans/2026-07-22-host-capability-boundary.md).

- Adds JSDoc to `deepStrictEqual` (`lib/utils/comparison.js`) and `prettyPrint` (`lib/utils/formatting.js`) marking them as reimplementable-semantics seams per ADR 0018: a port targeting another language reimplements these natively instead of depending on Node's `util.isDeepStrictEqual`/`util.inspect`.
- No behavioural change.

## Test plan
- [x] `npm test` — all suites green (462 tests, no new tests needed per plan — doc-only change)
- [x] `npm run lint` — clean