### PR TITLE
refactor: route JSON document reading through NodeFileSystem.readJson (Phase 4, scoped)

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -1,11 +1,9 @@
+import { fileURLToPath, URL } from 'node:url';
 import { FailFast } from './fail_fast.js';
 import { NodeFileSystem } from '../host/file_system.js';
 
-// Change to import assertions when reaching Node 18
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-
 const CONFIGURATION_FILE_NAME = '.testyrc.json';
+const DEFAULT_CONFIGURATION_PATH = fileURLToPath(new URL('./default_configuration.json', import.meta.url));
 const fileSystem = new NodeFileSystem();
 
 /**
@@ -23,9 +21,9 @@ export class Configuration {
 
   static current() {
     let userConfiguration = {};
-    const defaultConfiguration = require('./default_configuration.json');
+    const defaultConfiguration = fileSystem.readJson(DEFAULT_CONFIGURATION_PATH);
     try {
-      userConfiguration = require(fileSystem.resolvePathFor(CONFIGURATION_FILE_NAME));
+      userConfiguration = fileSystem.readJson(fileSystem.resolvePathFor(CONFIGURATION_FILE_NAME));
       // eslint-disable-next-line no-unused-vars
     } catch (_error) {
       // returning an empty object as configuration is fine
@@ -35,8 +33,8 @@ export class Configuration {
   }
 
   static withConfiguration(aConfiguration) {
-    const defaultConfiguration = require('./default_configuration.json');
-    const userConfiguration = require(fileSystem.resolvePathFor(CONFIGURATION_FILE_NAME));
+    const defaultConfiguration = fileSystem.readJson(DEFAULT_CONFIGURATION_PATH);
+    const userConfiguration = fileSystem.readJson(fileSystem.resolvePathFor(CONFIGURATION_FILE_NAME));
     return new this({ ...userConfiguration, ...aConfiguration }, defaultConfiguration);
   }
   constructor(userConfiguration, defaultConfiguration) {

--- a/lib/host/file_system.js
+++ b/lib/host/file_system.js
@@ -4,9 +4,9 @@ import process from 'node:process';
 
 /**
  * I am the host file system. I expose, in domain terms, the file and path operations Testy
- * needs: find test files under a directory, resolve a path, answer a path's extension, and
- * remove a temporary file. The core never names Node's fs/path APIs directly. See decision
- * 0018 (host capability catalog).
+ * needs: find test files under a directory, resolve a path, answer a path's extension, read
+ * a JSON document, and remove a temporary file. The core never names Node's fs/path APIs
+ * directly. See decision 0018 (host capability catalog).
  */
 export class NodeFileSystem {
   resolvePathFor(relativePath) {
@@ -28,5 +28,9 @@ export class NodeFileSystem {
     if (filePath && fs.existsSync(filePath)) {
       fs.unlinkSync(filePath);
     }
+  }
+
+  readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
   }
 }

--- a/lib/i18n/i18n.js
+++ b/lib/i18n/i18n.js
@@ -1,11 +1,10 @@
+import { fileURLToPath, URL } from 'node:url';
 import { isUndefined } from '../utils/index.js';
 import { InvalidConfigurationError } from '../errors.js';
+import { NodeFileSystem } from '../host/file_system.js';
 
-// Change to import assertions when reaching Node 22
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const TRANSLATIONS = require('./translations');
+const TRANSLATIONS_PATH = fileURLToPath(new URL('./translations.json', import.meta.url));
+const TRANSLATIONS = new NodeFileSystem().readJson(TRANSLATIONS_PATH);
 
 class I18n {
   #languageCode;

--- a/lib/script_action.js
+++ b/lib/script_action.js
@@ -1,14 +1,13 @@
 /* eslint-disable max-classes-per-file */
+import { fileURLToPath, URL } from 'node:url';
 import { Testy } from './testy.js';
 import { Configuration } from './config/configuration.js';
 import { ConfigurationParsingError, InvalidConfigurationError } from './errors.js';
 import { ParametersParser } from './config/parameters_parser.js';
+import { NodeFileSystem } from './host/file_system.js';
 
-// Change to import assertions when reaching Node 22
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const packageData = require('../package.json');
+const PACKAGE_JSON_PATH = fileURLToPath(new URL('../package.json', import.meta.url));
+const packageData = new NodeFileSystem().readJson(PACKAGE_JSON_PATH);
 
 export class ScriptAction {
   #process;

--- a/lib/ui/json_formatter.js
+++ b/lib/ui/json_formatter.js
@@ -1,8 +1,9 @@
-import { createRequire } from 'node:module';
+import { fileURLToPath, URL } from 'node:url';
 import { Formatter } from './formatter.js';
+import { NodeFileSystem } from '../host/file_system.js';
 
-const require = createRequire(import.meta.url);
-const { name: toolName, version: toolVersion } = require('../../package.json');
+const PACKAGE_JSON_PATH = fileURLToPath(new URL('../../package.json', import.meta.url));
+const { name: toolName, version: toolVersion } = new NodeFileSystem().readJson(PACKAGE_JSON_PATH);
 
 /**
  * I accumulate test results as the run progresses and emit a single structured JSON document

--- a/tests/core/script_action_test.js
+++ b/tests/core/script_action_test.js
@@ -1,0 +1,31 @@
+import { assert, suite, test, before } from '../../lib/testy.js';
+import { ScriptAction } from '../../lib/script_action.js';
+import { FakeProcess } from '../ui/fake_process.js';
+import { FakeConsole } from '../ui/fake_console.js';
+
+suite('ScriptAction', () => {
+  let fakeProcess, fakeConsole;
+
+  before(() => {
+    fakeProcess = new FakeProcess();
+    fakeConsole = new FakeConsole();
+  });
+
+  test('-v shows the version, reading it from package.json', async() => {
+    const action = ScriptAction.for(['-v'], fakeProcess, fakeConsole);
+    await action.execute();
+
+    assert.that(fakeConsole.messages().length).isEqualTo(1);
+    assert.that(fakeConsole.messages().at(0)).matches(/Testy version: \d+\.\d+\.\d+/);
+    assert.that(fakeProcess.lastExitCode()).isEqualTo(0);
+  });
+
+  test('--help shows usage information', async() => {
+    const action = ScriptAction.for(['--help'], fakeProcess, fakeConsole);
+    await action.execute();
+
+    assert.that(fakeConsole.messages().length).isEqualTo(1);
+    assert.that(fakeConsole.messages().at(0)).matches(/Usage:/);
+    assert.that(fakeProcess.lastExitCode()).isEqualTo(0);
+  });
+});

--- a/tests/host/file_system_test.js
+++ b/tests/host/file_system_test.js
@@ -47,4 +47,10 @@ suite('node file system', () => {
     fileSystem.deleteFileIfExists(path.join(tempDir, 'ghost.js'));
     assert.isTrue(true);
   });
+
+  test('reads and parses a JSON document', () => {
+    const jsonFile = path.join(tempDir, 'data.json');
+    fs.writeFileSync(jsonFile, JSON.stringify({ name: 'testy', nested: { ok: true } }));
+    assert.that(fileSystem.readJson(jsonFile)).isEqualTo({ name: 'testy', nested: { ok: true } });
+  });
 });


### PR DESCRIPTION
## Summary
Implements the JSON-reading slice of Phase 4 from doc/plans/2026-07-22-host-capability-boundary.md (ADR 0018), scoped narrowly per discussion: swap `createRequire`-based JSON loading for `NodeFileSystem.readJson` at each existing call site, without restructuring construction into a shared composition root (that part remains deferred — it's a DRY nicety, not required by ADR 0018).

- `NodeFileSystem.readJson(path)` — wraps `fs.readFileSync` + `JSON.parse` (decision point resolved: module-resolution semantics of `createRequire` don't matter here — every remaining call site already resolves an absolute path itself, either via `NodeFileSystem.resolvePathFor` (cwd-relative, for user files like `.testyrc.json`) or via `fileURLToPath(new URL(..., import.meta.url))` (module-relative, for library-bundled files like `package.json`/`translations.json`/`default_configuration.json`)).
- Migrated all four `createRequire` call sites named in ADR 0018's capability #6: `lib/config/configuration.js`, `lib/i18n/i18n.js`, `lib/script_action.js`, `lib/ui/json_formatter.js`.
- Added `tests/core/script_action_test.js` — `ScriptAction` had **zero** test coverage before this change; since this PR touches its package.json-reading path, added focused coverage per the repo's self-testing convention.
- `lib/typescript/typescript_transpiler.js` still uses `createRequire` — left untouched, it's explicitly out of scope per ADR 0018 (host-specific extension, not portable core).

Not included (deferred, not required by ADR 0018): unifying the duplicate `package.json` reads in `script_action.js`/`json_formatter.js` into a single composition root. That would require restructuring `dsl.js`'s eagerly-constructed module-level singletons for a DRY-only gain — bigger blast radius for no portability benefit.

## Test plan
- [x] `npm test` — all suites green (465 tests)
- [x] `npm run lint` — clean
- [x] `node bin/simplicity-guardian.js` — passes
- [x] New `tests/host/file_system_test.js` case for `readJson`
- [x] New `tests/core/script_action_test.js` (previously untested file)
- [x] Existing `configuration_test.js`, `console_ui_test.js` (`Configuration.current()`), `i18n_test.js`, `translation_keys_consistency_test.js`, `json_formatter_test.js` all stay green — confirms no behavioural regression