### PR TITLE
chore(deps): ignore typescript major version updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       time: "08:00"
     allow:
       - dependency-type: "all"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"


### PR DESCRIPTION
Agrega una regla de \`ignore\` para que Dependabot deje de proponer majors de \`typescript\`.

Motivo: TypeScript 6 rompe \`tsc --project tsconfig.json\` (errores \`TS4094\` por los campos privados \`#key\`/\`#params\` en clases anónimas exportadas, usados para generar \`dist/types/*.d.ts\`). El CI actual no lo detecta porque \`node_ci.yml\` nunca ejecuta \`npm run build:types\`. Ver el análisis en #410, donde se excluyó ese major del batch de actualizaciones (#386 y el equivalente de Renovate #378, ambos cerrados).

Cuando se resuelva la incompatibilidad con TS 6 (o se ajuste el uso de campos privados), se puede quitar esta regla.