### PR TITLE
fix(deps): move typescript to optional peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,24 @@
       "name": "@pmoo/testy",
       "version": "8.0.0",
       "license": "MIT",
-      "dependencies": {
-        "typescript": "^5.9.2"
-      },
       "bin": {
         "testy": "bin/testy_cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "eslint": "^10.8.0"
+        "eslint": "^10.8.0",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">= 20.*"
+      },
+      "peerDependencies": {
+        "typescript": "^5.9.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -877,6 +883,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -66,9 +66,15 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "eslint": "^10.8.0"
-  },
-  "dependencies": {
+    "eslint": "^10.8.0",
     "typescript": "^5.9.2"
+  },
+  "peerDependencies": {
+    "typescript": "^5.9.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## What

`typescript` was declared under `"dependencies"` in `package.json`, meaning every consumer of `@pmoo/testy` had it installed transitively as a runtime dependency — even though [`lib/typescript/typescript_transpiler.js`](lib/typescript/typescript_transpiler.js) already loads it lazily from the *user's own project* (via `createRequire`) only when a `.ts` test file is encountered, and throws `MissingTypescriptDependencyError` otherwise.

This contradicted:
- The zero-dependencies policy (`doc/decisions/0003-zero-dependencies.md` / Project DNA in `CLAUDE.md`).
- The PR #347 description itself, which states "Testy includes Typescript as peer dependency".

## Change

- Moved `typescript` out of `"dependencies"`.
- Added it to `"devDependencies"` (still needed locally for `npm run build:types`, which runs `tsc`).
- Declared it as an optional `peerDependency` (`peerDependenciesMeta.typescript.optional = true`), so consumers who want `.ts` test file support install it themselves, and npm won't warn/require it otherwise.
- Regenerated `package-lock.json` accordingly.

## Verification

- `npm test` — 465/465 passing.
- `npm run lint` — clean.
- `node bin/simplicity-guardian.js` — all checks passed.
- `npm run build:types` — still works locally with `typescript` as a devDependency.

## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)