### PR TITLE
fix(core): stop TestFileLoader from ever deleting original source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ reports/
 # Mutation testing temp files
 .stryker-tmp
 
+# TypeScript transpilation cache
+.testy-cache
+
 # JSDoc
 doc/jsdoc/
 

--- a/lib/core/test_file_loader.js
+++ b/lib/core/test_file_loader.js
@@ -53,15 +53,15 @@ export class TestFileLoader {
   // eslint-disable-next-line max-statements
   async #loadFileHandlingErrors(filePath) {
     let importPath = filePath;
-    let isTempFileCreated = false;
+    let temporaryFilePath = null;
 
     try {
       this.#testRunner.loadingFile(filePath);
       const fileExtension = this.#fileSystem.extensionOf(filePath);
 
       if (fileExtension === '.ts') {
-        const transpilationResult = await TypescriptTranspiler.generateTemporalJavascriptFromTypescript(filePath);
-        ({ importPath, isTempFileCreated } = transpilationResult);
+        ({ importPath: temporaryFilePath } = await TypescriptTranspiler.generateTemporalJavascriptFromTypescript(filePath));
+        importPath = temporaryFilePath;
       }
 
       await this.#moduleLoader.load(importPath);
@@ -71,19 +71,19 @@ export class TestFileLoader {
         I18nMessage.of('feedback_for_error_loading_suite'),
       );
     } finally {
-      this.#cleanupTemporaryFile(isTempFileCreated, importPath);
+      this.#cleanupTemporaryFile(temporaryFilePath);
     }
   }
 
-  #cleanupTemporaryFile(shouldRemoveFile, path) {
-    if (!shouldRemoveFile) {
+  #cleanupTemporaryFile(temporaryFilePath) {
+    if (!temporaryFilePath) {
       return;
     }
     try {
-      this.#fileSystem.deleteFileIfExists(path);
+      this.#fileSystem.deleteFileIfExists(temporaryFilePath);
     } catch (cleanupError) {
       this.#ui.exitWithError(
-        I18nMessage.of('error_deleting_temporary_file', path), errorDetailOf(cleanupError),
+        I18nMessage.of('error_deleting_temporary_file', temporaryFilePath), errorDetailOf(cleanupError),
       );
     }
   }

--- a/lib/typescript/typescript_transpiler.js
+++ b/lib/typescript/typescript_transpiler.js
@@ -17,7 +17,7 @@ export class TypescriptTranspiler {
     const tempFilePath = path.join(tempDir, `${path.basename(filePath)}.js`);
     fs.writeFileSync(tempFilePath, jsCode);
 
-    return { importPath: tempFilePath, isTempFileCreated: true };
+    return { importPath: tempFilePath };
   }
 
   static async transpileTypeScript(typescriptCode) {

--- a/tests/core/fixtures/loader_fixture_ok.ts
+++ b/tests/core/fixtures/loader_fixture_ok.ts
@@ -1,0 +1,2 @@
+// Fixture used by test_file_loader_test.js: a valid TypeScript module that loads without error.
+export const loadedMarker: string = 'loader-fixture-ok-ts';

--- a/tests/core/test_file_loader_test.js
+++ b/tests/core/test_file_loader_test.js
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { assert, suite, test, before } from '../../lib/testy.js';
 import { TestFileLoader } from '../../lib/core/test_file_loader.js';
 import { ConsoleUI } from '../../lib/ui/console_ui.js';
@@ -62,6 +63,18 @@ suite('TestFileLoader', () => {
       await loader.loadAll([fixturesDir], /loader_fixture_ok\.js$/u);
 
       assert.that(seen.length).isGreaterThan(0);
+    });
+  });
+
+  test('transpiles a TypeScript file and never deletes the original source file', async() => {
+    await withRunner(async runner => {
+      const loader = new TestFileLoader(ui, runner);
+      const originalSourcePath = `${fixturesDir}/loader_fixture_ok.ts`;
+
+      await loader.loadAll([fixturesDir], /loader_fixture_ok\.ts$/u);
+
+      assert.that(fakeProcess.lastExitCode()).isNull();
+      assert.isTrue(existsSync(originalSourcePath));
     });
   });
 


### PR DESCRIPTION
## Summary
- `TestFileLoader#loadFileHandlingErrors` tracked a boolean (`isTempFileCreated`) and a reused path (`importPath`) separately to decide what to clean up after loading a file. A mutation could desync them, making cleanup delete the **original** test source file instead of a transpiled temp copy.
- Since Stryker's mutation testing never restores `tests/**` (only `{src,lib}/**` is backed up/restored), one such deletion permanently lost coverage from that file's tests for the rest of the run, cascading into a collapsed mutation score. This is what was silently driving the Stryker Dashboard's 46.07% score down for months, with several fully-covered files showing 100% survived mutants.
- Fix: replaced the redundant boolean with a single `temporaryFilePath` value that can only ever be the actual generated temp path, so cleanup structurally cannot target the original file.

Fixes #420

## Test plan
- [x] Added a regression test that loads a real `.ts` fixture through the actual `TypescriptTranspiler` and asserts the original source file still exists afterwards.
- [x] `npm test` — 466/466 passing.
- [x] `npm run lint` — clean.
- [x] Verified locally with real Stryker runs: the batch of previously-100%-survived files went from 1.79% to 82.09% mutation score; a full local run matching the exact CI command went from 46.07% to 84.38%, in line with the project's ~95.72% statement coverage.