### PR TITLE
fix(core): resolve JSDoc/behavior inconsistencies in assertions

### DIFF
--- a/lib/core/asserter.js
+++ b/lib/core/asserter.js
@@ -249,7 +249,7 @@ class Asserter extends TestResultReporter {
 
   /**
    * Expects two given objects to be identical, that is, to share the same reference.
-   * This is a shortcut of the [that]{@link Asserter#that} syntax followed by a [isIdenticalTo]{@link Assertion#isEqualTo} assertion.
+   * This is a shortcut of the [that]{@link Asserter#that} syntax followed by a [isIdenticalTo]{@link Assertion#isIdenticalTo} assertion.
    *
    * @example literals
    * assert.areIdentical(3, 3)

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -290,7 +290,7 @@ export class Assertion extends TestResultReporter {
    * assert.that(3).isIncludedIn(new Set([1, 2, 3]))
    *
    * @example string
-   * assert.that('lo').isIncludedIn('hello')
+   * assert.that('l').isIncludedIn('hello')
    *
    * @param {Array|Set|Map|String} expectedCollection the collection that you are expecting the `actual` to be included in.
    * @param {Function} [equalityCriteria] a two-argument function to be used to compare elements from the
@@ -299,7 +299,7 @@ export class Assertion extends TestResultReporter {
    * @returns {void}
    */
   isIncludedIn(expectedCollection, equalityCriteria) {
-    const resultIsSuccessful = expectedCollection.find(element =>
+    const resultIsSuccessful = convertToArray(expectedCollection).find(element =>
       this.#areConsideredEqual(element, this.#actual, equalityCriteria));
     const failureMessage = () => I18nMessage.of('expectation_be_included_in', this.#actualResultAsString(), prettyPrint(expectedCollection));
     this.#reportAssertionResult(resultIsSuccessful, failureMessage);
@@ -351,7 +351,7 @@ export class Assertion extends TestResultReporter {
    * @returns {void}
    */
   isNotIncludedIn(expectedCollection, equalityCriteria) {
-    const resultIsSuccessful = !expectedCollection.find(element =>
+    const resultIsSuccessful = !convertToArray(expectedCollection).find(element =>
       this.#areConsideredEqual(element, this.#actual, equalityCriteria));
     const failureMessage = () => I18nMessage.of('expectation_be_not_included_in', this.#actualResultAsString(), prettyPrint(expectedCollection));
     this.#reportAssertionResult(resultIsSuccessful, failureMessage);

--- a/tests/core/assertions/collection_assertions_test.js
+++ b/tests/core/assertions/collection_assertions_test.js
@@ -262,6 +262,24 @@ suite('collection assertions', () => {
     expectFailureOn(result, I18nMessage.of('expectation_be_included_in', '\'hey\'', '[ 1, 2, 3 ]'));
   });
 
+  test('isIncludedIn works with Sets', async() => {
+    const result = await resultOfATestWith(assert => assert.that(3).isIncludedIn(new Set([1, 2, 3])));
+
+    expectSuccess(result);
+  });
+
+  test('isIncludedIn works with Maps', async() => {
+    const result = await resultOfATestWith(assert => assert.that(42).isIncludedIn(new Map([['key', 42]])));
+
+    expectSuccess(result);
+  });
+
+  test('isIncludedIn works with Strings', async() => {
+    const result = await resultOfATestWith(assert => assert.that('l').isIncludedIn('hello'));
+
+    expectSuccess(result);
+  });
+
   // isNotIncludedIn() assertion tests
 
   test('isNotIncludedIn is successful when the actual object is not part of the expected list', async() => {
@@ -274,5 +292,23 @@ suite('collection assertions', () => {
     const result = await resultOfATestWith(assert => assert.that(1).isNotIncludedIn([1, 2, 3]));
 
     expectFailureOn(result, I18nMessage.of('expectation_be_not_included_in', '1', '[ 1, 2, 3 ]'));
+  });
+
+  test('isNotIncludedIn works with Sets', async() => {
+    const result = await resultOfATestWith(assert => assert.that(4).isNotIncludedIn(new Set([1, 2, 3])));
+
+    expectSuccess(result);
+  });
+
+  test('isNotIncludedIn works with Maps', async() => {
+    const result = await resultOfATestWith(assert => assert.that(4).isNotIncludedIn(new Map([['key', 42]])));
+
+    expectSuccess(result);
+  });
+
+  test('isNotIncludedIn works with Strings', async() => {
+    const result = await resultOfATestWith(assert => assert.that('x').isNotIncludedIn('hello'));
+
+    expectSuccess(result);
   });
 });


### PR DESCRIPTION
## What

An audit of every JSDoc comment in `lib/` against the code it documents turned up two inconsistencies in `lib/core/assertion.js` and `lib/core/asserter.js`:

- `isIncludedIn`/`isNotIncludedIn` document (and give examples for) support of `Array`, `Set`, `Map` and `String`, but the implementation called `.find()` directly on `expectedCollection`. Only `Array` has that method, so passing a `Set`, `Map`, or `String` — exactly as the JSDoc examples show — throws a `TypeError` at runtime. Fixed by routing `expectedCollection` through the existing `convertToArray` helper, mirroring how the `includes`/`doesNotInclude` siblings already handle their own collection argument.
- The `isIncludedIn` String example used a two-character substring (`'lo'` in `'hello'`), which the per-element matching approach can never satisfy (it only matches single elements, as the sibling `includes` example correctly does with `'4'`, not `'42'`). Corrected the example to a single character.
- `areIdentical`'s doc comment linked to `Assertion#isEqualTo` instead of `Assertion#isIdenticalTo` — a copy-paste leftover from the `areEqual` doc block right above it.

Added tests covering `isIncludedIn`/`isNotIncludedIn` with `Set`, `Map`, and `String`, since this exercises previously-untested (and previously-broken) behavior.

`npm test` (472 passed) and `npm run lint` are clean.

## Link to issue(s)

- [Audit and fix JSDoc inconsistencies](https://github.com/ngarbezza/testy/issues/425)

## Contribution guidelines

- [x] I have read the [Contributing guidelines](/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XaPjfhJEGfzuN5LdG3Y8FN)_